### PR TITLE
chore: update gapic-generator-python to 0.40.8

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -236,8 +236,8 @@ pip_repositories()
 # Change upstream repository once PR is merged
 http_archive(
     name = "gapic_generator_python",
-    strip_prefix = "gapic-generator-python-0.40.0",
-    urls = ["https://github.com/googleapis/gapic-generator-python/archive/v0.40.0.zip"],
+    strip_prefix = "gapic-generator-python-0.40.8",
+    urls = ["https://github.com/googleapis/gapic-generator-python/archive/v0.40.8.zip"],
 )
 
 load(


### PR DESCRIPTION
fix: raise for rest transport http error
fix: fix rest transport unit test template
fix: stabilize order of query_params
fix: remove duplicate assignment of certain flattened, repeated fields
fix: don't use integer for enums in json encoding
fix: body encoding for rest transport
fix: update paging implementation to handle unconventional pagination