### PR TITLE
chore: upgrade to gapic-generator-python 0.40.10

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -231,8 +231,8 @@ pip_repositories()
 
 http_archive(
     name = "gapic_generator_python",
-    strip_prefix = "gapic-generator-python-0.40.9",
-    urls = ["https://github.com/googleapis/gapic-generator-python/archive/v0.40.9.zip"],
+    strip_prefix = "gapic-generator-python-0.40.10",
+    urls = ["https://github.com/googleapis/gapic-generator-python/archive/v0.40.10.zip"],
 )
 
 load(


### PR DESCRIPTION
fix: ignore unknown fields returned from server for REST

For https://github.com/googleapis/python-compute/issues/24