### PR TITLE
chore: Update disco-to-proto3-converter with 2^29 as maximum field number

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -407,8 +407,8 @@ gapic_generator_ruby_repositories()
 
 http_archive(
     name = "com_google_disco_to_proto3_converter",
-    strip_prefix = "disco-to-proto3-converter-451838644577e9054eeb378d0514a8c089bc3302",
-    urls = ["https://github.com/googleapis/disco-to-proto3-converter/archive/451838644577e9054eeb378d0514a8c089bc3302.zip"],
+    strip_prefix = "disco-to-proto3-converter-6f13b7022a0c0d19ee5a90508082e55b028e1c43",
+    urls = ["https://github.com/googleapis/disco-to-proto3-converter/archive/6f13b7022a0c0d19ee5a90508082e55b028e1c43.zip"],
 )
 
 load("@com_google_disco_to_proto3_converter//:repository_rules.bzl", "com_google_disco_to_proto3_converter_properties")

--- a/google/cloud/compute/v1/compute.proto
+++ b/google/cloud/compute/v1/compute.proto
@@ -46,7 +46,7 @@ option ruby_package = "Google::Cloud::Compute::V1";
 // A specification of the type and number of accelerator cards attached to the instance.
 message AcceleratorConfig {
   // The number of the guest accelerator cards exposed to this instance.
-  optional int32 accelerator_count = 236444219;
+  optional int32 accelerator_count = 504879675;
 
   // Full or partial URL of the accelerator type resource to attach to this instance. For example: projects/my-project/zones/us-central1-c/acceleratorTypes/nvidia-tesla-p100 If you are creating an instance template, specify only the accelerator name. See GPUs on Compute Engine for a full list of accelerator types.
   optional string accelerator_type = 138031246;
@@ -60,27 +60,27 @@ message DeprecationStatus {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATE = 0;
 
-    ACTIVE = 46297862;
+    ACTIVE = 314733318;
 
     DELETED = 120962041;
 
-    DEPRECATED = 194924979;
+    DEPRECATED = 463360435;
 
     OBSOLETE = 66532761;
 
   }
 
   // An optional RFC3339 timestamp on or after which the state of this resource is intended to change to DELETED. This is only informational and the status will not change unless the client explicitly changes it.
-  optional string deleted = 208285721;
+  optional string deleted = 476721177;
 
   // An optional RFC3339 timestamp on or after which the state of this resource is intended to change to DEPRECATED. This is only informational and the status will not change unless the client explicitly changes it.
-  optional string deprecated = 246703539;
+  optional string deprecated = 515138995;
 
   // An optional RFC3339 timestamp on or after which the state of this resource is intended to change to OBSOLETE. This is only informational and the status will not change unless the client explicitly changes it.
-  optional string obsolete = 89212313;
+  optional string obsolete = 357647769;
 
   // The URL of the suggested replacement for a deprecated resource. The suggested replacement resource must be the same kind of resource as the deprecated resource.
-  optional string replacement = 162483730;
+  optional string replacement = 430919186;
 
   // The deprecation state of this resource. This can be ACTIVE, DEPRECATED, OBSOLETE, or DELETED. Operations which communicate the end of life date for an image, can use ACTIVE. Operations which create a new resource using a DEPRECATED resource will return successfully, but with a warning indicating the deprecated resource and recommending its replacement. Operations which use OBSOLETE or DELETED resources will be rejected and result in an error.
   optional State state = 109757585;
@@ -95,10 +95,10 @@ message AcceleratorType {
   optional string creation_timestamp = 30525366;
 
   // [Output Only] The deprecation status associated with this accelerator type.
-  optional DeprecationStatus deprecated = 246703539;
+  optional DeprecationStatus deprecated = 515138995;
 
   // [Output Only] An optional textual description of the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -113,7 +113,7 @@ message AcceleratorType {
   optional string name = 3373707;
 
   // [Output Only] Server-defined, fully qualified URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The name of the zone where the accelerator type resides, such as us-central1-a. You must specify this field as part of the HTTP request URL. It is not settable as a field in the request body.
   optional string zone = 3744684;
@@ -123,7 +123,7 @@ message AcceleratorType {
 //
 message AcceleratorTypesScopedList {
   // [Output Only] A list of accelerator types contained in this scope.
-  repeated AcceleratorType accelerator_types = 252436901;
+  repeated AcceleratorType accelerator_types = 520872357;
 
   // [Output Only] An informational warning that appears when the accelerator types list is empty.
   optional Warning warning = 50704284;
@@ -149,33 +149,33 @@ message Warning {
 
     CLEANUP_FAILED = 150308440;
 
-    DEPRECATED_RESOURCE_USED = 123400130;
+    DEPRECATED_RESOURCE_USED = 391835586;
 
-    DEPRECATED_TYPE_USED = 78090774;
+    DEPRECATED_TYPE_USED = 346526230;
 
-    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 101007511;
+    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 369442967;
 
-    EXPERIMENTAL_TYPE_USED = 183518987;
+    EXPERIMENTAL_TYPE_USED = 451954443;
 
     EXTERNAL_API_WARNING = 175546307;
 
-    FIELD_VALUE_OVERRIDEN = 61233967;
+    FIELD_VALUE_OVERRIDEN = 329669423;
 
-    INJECTED_KERNELS_DEPRECATED = 148941963;
+    INJECTED_KERNELS_DEPRECATED = 417377419;
 
-    LARGE_DEPLOYMENT_WARNING = 213005222;
+    LARGE_DEPLOYMENT_WARNING = 481440678;
 
-    MISSING_TYPE_DEPENDENCY = 76070007;
+    MISSING_TYPE_DEPENDENCY = 344505463;
 
-    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 56529543;
+    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 324964999;
 
-    NEXT_HOP_CANNOT_IP_FORWARD = 114947431;
+    NEXT_HOP_CANNOT_IP_FORWARD = 383382887;
 
-    NEXT_HOP_INSTANCE_NOT_FOUND = 195814990;
+    NEXT_HOP_INSTANCE_NOT_FOUND = 464250446;
 
     NEXT_HOP_INSTANCE_NOT_ON_NETWORK = 243758146;
 
-    NEXT_HOP_NOT_RUNNING = 148645809;
+    NEXT_HOP_NOT_RUNNING = 417081265;
 
     NOT_CRITICAL_ERROR = 105763924;
 
@@ -185,15 +185,15 @@ message Warning {
 
     REQUIRED_TOS_AGREEMENT = 3745539;
 
-    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 228293185;
+    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 496728641;
 
     RESOURCE_NOT_DELETED = 168598460;
 
-    SCHEMA_VALIDATION_IGNORED = 6810186;
+    SCHEMA_VALIDATION_IGNORED = 275245642;
 
     SINGLE_INSTANCE_PROPERTY_TEMPLATE = 268305617;
 
-    UNDECLARED_PROPERTIES = 122077983;
+    UNDECLARED_PROPERTIES = 390513439;
 
     UNREACHABLE = 13328052;
 
@@ -207,7 +207,7 @@ message Warning {
   repeated Data data = 3076010;
 
   // [Output Only] A human-readable description of the warning code.
-  optional string message = 149618695;
+  optional string message = 418054151;
 
 }
 
@@ -226,7 +226,7 @@ message AcceleratorTypeAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -251,7 +251,7 @@ message AcceleratorTypeList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -269,9 +269,9 @@ message AccessConfig {
     // A value indicating that the enum field is not set.
     UNDEFINED_NETWORK_TIER = 0;
 
-    PREMIUM = 131095095;
+    PREMIUM = 399530551;
 
-    STANDARD = 216207037;
+    STANDARD = 484642493;
 
   }
 
@@ -298,13 +298,13 @@ message AccessConfig {
   // If an AccessConfig is specified without a valid external IP address, an ephemeral IP will be created with this networkTier.
   //
   // If an AccessConfig with a valid external IP address is specified, it must match that of the networkTier associated with the Address resource owning that IP.
-  optional NetworkTier network_tier = 248962387;
+  optional NetworkTier network_tier = 517397843;
 
   // The DNS domain name for the public PTR record. You can set this field only if the `setPublicPtr` field is enabled.
-  optional string public_ptr_domain_name = 48163711;
+  optional string public_ptr_domain_name = 316599167;
 
   // Specifies whether a public DNS 'PTR' record should be created to map the external IP address of the instance to a DNS domain name.
-  optional bool set_public_ptr = 255434773;
+  optional bool set_public_ptr = 523870229;
 
   // The type of configuration. The default and only option is ONE_TO_ONE_NAT.
   optional Type type = 3575610;
@@ -334,7 +334,7 @@ message Address {
 
     EXTERNAL = 35607499;
 
-    INTERNAL = 10860221;
+    INTERNAL = 279295677;
 
     UNSPECIFIED_TYPE = 53933922;
 
@@ -360,9 +360,9 @@ message Address {
     // A value indicating that the enum field is not set.
     UNDEFINED_NETWORK_TIER = 0;
 
-    PREMIUM = 131095095;
+    PREMIUM = 399530551;
 
-    STANDARD = 216207037;
+    STANDARD = 484642493;
 
   }
 
@@ -376,15 +376,15 @@ message Address {
     // A value indicating that the enum field is not set.
     UNDEFINED_PURPOSE = 0;
 
-    DNS_RESOLVER = 207679100;
+    DNS_RESOLVER = 476114556;
 
     GCE_ENDPOINT = 230515243;
 
     NAT_AUTO = 163666477;
 
-    SHARED_LOADBALANCER_VIP = 26012116;
+    SHARED_LOADBALANCER_VIP = 294447572;
 
-    VPC_PEERING = 132364714;
+    VPC_PEERING = 400800170;
 
   }
 
@@ -395,14 +395,14 @@ message Address {
 
     IN_USE = 17393485;
 
-    RESERVED = 163805992;
+    RESERVED = 432241448;
 
-    RESERVING = 246151769;
+    RESERVING = 514587225;
 
   }
 
   // The static IP address represented by this resource.
-  optional string address = 194485236;
+  optional string address = 462920692;
 
   // The type of address to reserve, either INTERNAL or EXTERNAL. If unspecified, defaults to EXTERNAL.
   optional AddressType address_type = 264307877;
@@ -411,13 +411,13 @@ message Address {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this field when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
 
   // The IP version that will be used by this address. Valid options are IPV4 or IPV6. This can only be specified for a global address.
-  optional IpVersion ip_version = 26524096;
+  optional IpVersion ip_version = 294959552;
 
   // [Output Only] Type of the resource. Always compute#address for addresses.
   optional string kind = 3292052;
@@ -431,10 +431,10 @@ message Address {
   // This signifies the networking tier used for configuring this address and can only take the following values: PREMIUM or STANDARD. Global forwarding rules can only be Premium Tier. Regional forwarding rules can be either Premium or Standard Tier. Standard Tier addresses applied to regional forwarding rules can be used with any external load balancer. Regional forwarding rules in Premium Tier can only be used with a network load balancer.
   //
   // If this field is not specified, it is assumed to be PREMIUM.
-  optional NetworkTier network_tier = 248962387;
+  optional NetworkTier network_tier = 517397843;
 
   // The prefix length if the resource reprensents an IP range.
-  optional int32 prefix_length = 185130291;
+  optional int32 prefix_length = 453565747;
 
   // The purpose of this resource, which can be one of the following values:
   // - `GCE_ENDPOINT` for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
@@ -442,19 +442,19 @@ message Address {
   // - `VPC_PEERING` for addresses that are reserved for VPC peer networks.
   // - `NAT_AUTO` for addresses that are external IP addresses automatically reserved for Cloud NAT.
   // - `IPSEC_INTERCONNECT` for addresses created from a private IP range that are reserved for a VLAN attachment in an IPsec encrypted Interconnect configuration. These addresses are regional resources.
-  optional Purpose purpose = 47971614;
+  optional Purpose purpose = 316407070;
 
   // [Output Only] The URL of the region where the regional address resides. This field is not applicable to global addresses. You must specify this field as part of the HTTP request URL.
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The status of the address, which can be one of RESERVING, RESERVED, or IN_USE. An address that is RESERVING is currently in the process of being reserved. A RESERVED address is currently reserved and available to use. An IN_USE address is currently being used by another resource and is not available.
   optional Status status = 181260274;
 
   // The URL of the subnetwork in which to reserve the address. If an IP address is specified, it must be within the subnetwork's IP range. This field can only be used with INTERNAL type with a GCE_ENDPOINT or DNS_RESOLVER purpose.
-  optional string subnetwork = 39392238;
+  optional string subnetwork = 307827694;
 
   // [Output Only] The URLs of the resources that are using this address.
   repeated string users = 111578632;
@@ -464,7 +464,7 @@ message Address {
 //
 message AddressesScopedList {
   // [Output Only] A list of addresses contained in this scope.
-  repeated Address addresses = 69237666;
+  repeated Address addresses = 337673122;
 
   // [Output Only] Informational warning which replaces the list of addresses when the list is empty.
   optional Warning warning = 50704284;
@@ -486,7 +486,7 @@ message AddressAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -511,7 +511,7 @@ message AddressList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -524,7 +524,7 @@ message AliasIpRange {
   optional string ip_cidr_range = 98117322;
 
   // The name of a subnetwork secondary IP range from which to allocate an IP alias range. If not specified, the primary range of the subnetwork is used.
-  optional string subnetwork_range_name = 119560510;
+  optional string subnetwork_range_name = 387995966;
 
 }
 
@@ -542,17 +542,17 @@ message AllocationSpecificSKUAllocationAllocatedInstancePropertiesReservedDisk {
   }
 
   // Specifies the size of the disk in base-2 GB.
-  optional string disk_size_gb = 47828279;
+  optional string disk_size_gb = 316263735;
 
   // Specifies the disk interface to use for attaching this disk, which is either SCSI or NVME. The default is SCSI. For performance characteristics of SCSI over NVMe, see Local SSD performance.
-  optional Interface interface = 234188089;
+  optional Interface interface = 502623545;
 
 }
 
 // Properties of the SKU instances being reserved. Next ID: 9
 message AllocationSpecificSKUAllocationReservedInstanceProperties {
   // Specifies accelerator type and count.
-  repeated AcceleratorConfig guest_accelerators = 195159663;
+  repeated AcceleratorConfig guest_accelerators = 463595119;
 
   // Specifies amount of local ssd to reserve with each instance. The type of disk is local-ssd.
   repeated AllocationSpecificSKUAllocationAllocatedInstancePropertiesReservedDisk local_ssds = 229951299;
@@ -571,7 +571,7 @@ message AllocationSpecificSKUReservation {
   optional string count = 94851343;
 
   // [Output Only] Indicates how many instances are in use.
-  optional string in_use_count = 225023421;
+  optional string in_use_count = 493458877;
 
   // The instance properties for the reservation.
   optional AllocationSpecificSKUAllocationReservedInstanceProperties instance_properties = 215355165;
@@ -581,13 +581,13 @@ message AllocationSpecificSKUReservation {
 //
 message CustomerEncryptionKey {
   // The name of the encryption key that is stored in Google Cloud KMS.
-  optional string kms_key_name = 215938457;
+  optional string kms_key_name = 484373913;
 
   // The service account being used for the encryption request for the given KMS key. If absent, the Compute Engine default service account is used.
   optional string kms_key_service_account = 209986261;
 
   // Specifies a 256-bit customer-supplied encryption key, encoded in RFC 4648 base64 to either encrypt or decrypt this resource.
-  optional string raw_key = 180761032;
+  optional string raw_key = 449196488;
 
   // [Output only] The RFC 4648 base64 encoded SHA-256 hash of the customer-supplied encryption key that protects this resource.
   optional string sha256 = 170112551;
@@ -601,13 +601,13 @@ message GuestOsFeature {
     // A value indicating that the enum field is not set.
     UNDEFINED_TYPE = 0;
 
-    FEATURE_TYPE_UNSPECIFIED = 263331803;
+    FEATURE_TYPE_UNSPECIFIED = 531767259;
 
     GVNIC = 68209305;
 
     MULTI_IP_SUBNET = 151776719;
 
-    SECURE_BOOT = 108375738;
+    SECURE_BOOT = 376811194;
 
     SEV_CAPABLE = 87083793;
 
@@ -615,7 +615,7 @@ message GuestOsFeature {
 
     VIRTIO_SCSI_MULTIQUEUE = 201597069;
 
-    WINDOWS = 188427875;
+    WINDOWS = 456863331;
 
   }
 
@@ -633,22 +633,22 @@ message AttachedDiskInitializeParams {
     // A value indicating that the enum field is not set.
     UNDEFINED_ON_UPDATE_ACTION = 0;
 
-    RECREATE_DISK = 226332397;
+    RECREATE_DISK = 494767853;
 
-    RECREATE_DISK_IF_SOURCE_CHANGED = 129664256;
+    RECREATE_DISK_IF_SOURCE_CHANGED = 398099712;
 
     USE_EXISTING_DISK = 232682233;
 
   }
 
   // An optional description. Provide this property when creating the disk.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Specifies the disk name. If not specified, the default is to use the name of the instance. If a disk with the same name already exists in the given region, the existing disk is attached to the new instance and the new disk is not created.
   optional string disk_name = 92807149;
 
   // Specifies the size of the disk in base-2 GB. The size must be at least 10 GB. If you specify a sourceImage, which is required for boot disks, the default size is the size of the sourceImage. If you do not specify a sourceImage, the default disk size is 500 GB.
-  optional string disk_size_gb = 47828279;
+  optional string disk_size_gb = 316263735;
 
   // Specifies the disk type to use to create the instance. If not specified, the default is pd-standard, specified using the full URL. For example:
   // https://www.googleapis.com/compute/v1/projects/project/zones/zone/diskTypes/pd-standard
@@ -661,7 +661,7 @@ message AttachedDiskInitializeParams {
   optional string disk_type = 93009052;
 
   // Labels to apply to this disk. These can be later modified by the disks.setLabels method. This field is only applicable for persistent disks.
-  map<string, string> labels = 231759871;
+  map<string, string> labels = 500195327;
 
   // Specifies which action to take on instance update with this disk. Default is to use the existing disk.
   optional OnUpdateAction on_update_action = 202451980;
@@ -693,7 +693,7 @@ message AttachedDiskInitializeParams {
   // The customer-supplied encryption key of the source image. Required if the source image is protected by a customer-supplied encryption key.
   //
   // Instance templates do not store customer-supplied encryption keys, so you cannot create disks for instances in a managed instance group if the source images are encrypted with your own keys.
-  optional CustomerEncryptionKey source_image_encryption_key = 113068203;
+  optional CustomerEncryptionKey source_image_encryption_key = 381503659;
 
   // The source snapshot to create this disk. When creating a new instance, one of initializeParams.sourceSnapshot or initializeParams.sourceImage or disks.source is required except for local SSD.
   //
@@ -705,7 +705,7 @@ message AttachedDiskInitializeParams {
   optional string source_snapshot = 126061928;
 
   // The customer-supplied encryption key of the source snapshot.
-  optional CustomerEncryptionKey source_snapshot_encryption_key = 35243866;
+  optional CustomerEncryptionKey source_snapshot_encryption_key = 303679322;
 
 }
 
@@ -754,14 +754,14 @@ message AttachedDisk {
     // A value indicating that the enum field is not set.
     UNDEFINED_TYPE = 0;
 
-    PERSISTENT = 192248471;
+    PERSISTENT = 460683927;
 
-    SCRATCH = 228343514;
+    SCRATCH = 496778970;
 
   }
 
   // Specifies whether the disk will be auto-deleted when the instance is deleted (but not when the disk is detached from the instance).
-  optional bool auto_delete = 196325947;
+  optional bool auto_delete = 464761403;
 
   // Indicates that this is a boot disk. The virtual machine will use the first partition of the disk for its root filesystem.
   optional bool boot = 3029746;
@@ -780,10 +780,10 @@ message AttachedDisk {
   // If you do not provide an encryption key, then the disk will be encrypted using an automatically generated key and you do not need to provide a key to use the disk later.
   //
   // Instance templates do not store customer-supplied encryption keys, so you cannot use your own keys to encrypt disks in a managed instance group.
-  optional CustomerEncryptionKey disk_encryption_key = 3225221;
+  optional CustomerEncryptionKey disk_encryption_key = 271660677;
 
   // The size of the disk in GB.
-  optional string disk_size_gb = 47828279;
+  optional string disk_size_gb = 316263735;
 
   // A list of features to enable on the guest operating system. Applicable only for bootable images. Read  Enabling guest operating system features to see a list of available options.
   repeated GuestOsFeature guest_os_features = 79294545;
@@ -797,13 +797,13 @@ message AttachedDisk {
   optional AttachedDiskInitializeParams initialize_params = 17697045;
 
   // Specifies the disk interface to use for attaching this disk, which is either SCSI or NVME. The default is SCSI. Persistent disks must always use SCSI and the request will fail if you attempt to attach a persistent disk in any other format than SCSI. Local SSDs can use either NVME or SCSI. For performance characteristics of SCSI over NVMe, see Local SSD performance.
-  optional Interface interface = 234188089;
+  optional Interface interface = 502623545;
 
   // [Output Only] Type of the resource. Always compute#attachedDisk for attached disks.
   optional string kind = 3292052;
 
   // [Output Only] Any valid publicly visible licenses.
-  repeated string licenses = 69207122;
+  repeated string licenses = 337642578;
 
   // The mode in which to attach this disk, either READ_WRITE or READ_ONLY. If not specified, the default is to attach the disk in READ_WRITE mode.
   optional Mode mode = 3357091;
@@ -836,9 +836,9 @@ message AuditLogConfig {
 
     ADMIN_READ = 128951462;
 
-    DATA_READ = 36789515;
+    DATA_READ = 305224971;
 
-    DATA_WRITE = 71746282;
+    DATA_WRITE = 340181738;
 
     LOG_TYPE_UNSPECIFIED = 154527053;
 
@@ -850,7 +850,7 @@ message AuditLogConfig {
   optional bool ignore_child_exemptions = 70141850;
 
   // The log type that this config enables.
-  optional LogType log_type = 134680405;
+  optional LogType log_type = 403115861;
 
 }
 
@@ -865,12 +865,12 @@ message AuditLogConfig {
 // For sampleservice, this policy enables DATA_READ, DATA_WRITE and ADMIN_READ logging. It also exempts jose@example.com from DATA_READ logging, and aliya@example.com from DATA_WRITE logging.
 message AuditConfig {
   // The configuration for logging of each type of permission.
-  repeated AuditLogConfig audit_log_configs = 219985170;
+  repeated AuditLogConfig audit_log_configs = 488420626;
 
   repeated string exempted_members = 232615576;
 
   // Specifies a service that will be enabled for audit logging. For example, `storage.googleapis.com`, `cloudsql.googleapis.com`. `allServices` is a special value that covers all services.
-  optional string service = 105105077;
+  optional string service = 373540533;
 
 }
 
@@ -885,16 +885,16 @@ message AuthorizationLoggingOptions {
 
     ADMIN_WRITE = 244412079;
 
-    DATA_READ = 36789515;
+    DATA_READ = 305224971;
 
-    DATA_WRITE = 71746282;
+    DATA_WRITE = 340181738;
 
-    PERMISSION_TYPE_UNSPECIFIED = 171877890;
+    PERMISSION_TYPE_UNSPECIFIED = 440313346;
 
   }
 
   // The type of the permission that was checked.
-  optional PermissionType permission_type = 257543082;
+  optional PermissionType permission_type = 525978538;
 
 }
 
@@ -911,7 +911,7 @@ message AutoscalingPolicy {
 
     ONLY_SCALE_OUT = 152713670;
 
-    ONLY_UP = 209659918;
+    ONLY_UP = 478095374;
 
   }
 
@@ -921,24 +921,24 @@ message AutoscalingPolicy {
   optional int32 cool_down_period_sec = 107692954;
 
   // Defines the CPU utilization policy that allows the autoscaler to scale based on the average CPU utilization of a managed instance group.
-  optional AutoscalingPolicyCpuUtilization cpu_utilization = 112775691;
+  optional AutoscalingPolicyCpuUtilization cpu_utilization = 381211147;
 
   // Configuration parameters of autoscaling based on a custom metric.
   repeated AutoscalingPolicyCustomMetricUtilization custom_metric_utilizations = 131972850;
 
   // Configuration parameters of autoscaling based on load balancer.
-  optional AutoscalingPolicyLoadBalancingUtilization load_balancing_utilization = 161310947;
+  optional AutoscalingPolicyLoadBalancingUtilization load_balancing_utilization = 429746403;
 
   // The maximum number of instances that the autoscaler can scale out to. This is required when creating or updating an autoscaler. The maximum number of replicas must not be lower than minimal number of replicas.
   optional int32 max_num_replicas = 62327375;
 
   // The minimum number of replicas that the autoscaler can scale in to. This cannot be less than 0. If not provided, autoscaler chooses a default value depending on maximum number of instances allowed.
-  optional int32 min_num_replicas = 266894369;
+  optional int32 min_num_replicas = 535329825;
 
   // Defines operating mode for this policy.
   optional Mode mode = 3357091;
 
-  optional AutoscalingPolicyScaleInControl scale_in_control = 259235416;
+  optional AutoscalingPolicyScaleInControl scale_in_control = 527670872;
 
 }
 
@@ -965,13 +965,13 @@ message AutoscalerStatusDetails {
     // A value indicating that the enum field is not set.
     UNDEFINED_TYPE = 0;
 
-    ALL_INSTANCES_UNHEALTHY = 136530021;
+    ALL_INSTANCES_UNHEALTHY = 404965477;
 
     BACKEND_SERVICE_DOES_NOT_EXIST = 191417626;
 
     CAPPED_AT_MAX_NUM_REPLICAS = 518617;
 
-    CUSTOM_METRIC_DATA_POINTS_TOO_SPARSE = 60529203;
+    CUSTOM_METRIC_DATA_POINTS_TOO_SPARSE = 328964659;
 
     CUSTOM_METRIC_INVALID = 204430550;
 
@@ -979,7 +979,7 @@ message AutoscalerStatusDetails {
 
     MISSING_CUSTOM_METRIC_DATA_POINTS = 94885086;
 
-    MISSING_LOAD_BALANCING_DATA_POINTS = 241423442;
+    MISSING_LOAD_BALANCING_DATA_POINTS = 509858898;
 
     MODE_OFF = 164169907;
 
@@ -989,22 +989,22 @@ message AutoscalerStatusDetails {
 
     MORE_THAN_ONE_BACKEND_SERVICE = 151922141;
 
-    NOT_ENOUGH_QUOTA_AVAILABLE = 134666175;
+    NOT_ENOUGH_QUOTA_AVAILABLE = 403101631;
 
-    REGION_RESOURCE_STOCKOUT = 260187390;
+    REGION_RESOURCE_STOCKOUT = 528622846;
 
     SCALING_TARGET_DOES_NOT_EXIST = 122636699;
 
-    UNKNOWN = 164706346;
+    UNKNOWN = 433141802;
 
-    UNSUPPORTED_MAX_RATE_LOAD_BALANCING_CONFIGURATION = 62409553;
+    UNSUPPORTED_MAX_RATE_LOAD_BALANCING_CONFIGURATION = 330845009;
 
     ZONE_RESOURCE_STOCKOUT = 210200502;
 
   }
 
   // The status message.
-  optional string message = 149618695;
+  optional string message = 418054151;
 
   // The type of error, warning, or notice returned. Current set of possible values:
   // - ALL_INSTANCES_UNHEALTHY (WARNING): All instances in the instance group are unhealthy (not in RUNNING state).
@@ -1048,9 +1048,9 @@ message Autoscaler {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    ACTIVE = 46297862;
+    ACTIVE = 314733318;
 
-    DELETING = 260166568;
+    DELETING = 528602024;
 
     ERROR = 66247144;
 
@@ -1067,7 +1067,7 @@ message Autoscaler {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -1085,7 +1085,7 @@ message Autoscaler {
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The status of the autoscaler configuration. Current set of possible values:
   // - PENDING: Autoscaler backend hasn't read new/updated configuration.
@@ -1095,7 +1095,7 @@ message Autoscaler {
   optional Status status = 181260274;
 
   // [Output Only] Human-readable details about the current state of the autoscaler. Read the documentation for Commonly returned status messages for examples of status messages you might encounter.
-  repeated AutoscalerStatusDetails status_details = 94918389;
+  repeated AutoscalerStatusDetails status_details = 363353845;
 
   // URL of the managed instance group that this autoscaler will scale. This field is required when creating an autoscaler.
   optional string target = 192835985;
@@ -1108,7 +1108,7 @@ message Autoscaler {
 //
 message AutoscalersScopedList {
   // [Output Only] A list of autoscalers contained in this scope.
-  repeated Autoscaler autoscalers = 197336188;
+  repeated Autoscaler autoscalers = 465771644;
 
   // [Output Only] Informational warning which replaces the list of autoscalers when the list is empty.
   optional Warning warning = 50704284;
@@ -1130,7 +1130,7 @@ message AutoscalerAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -1155,7 +1155,7 @@ message AutoscalerList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -1200,19 +1200,19 @@ message AutoscalingPolicyCustomMetricUtilization {
   // If not specified, the type defaults to gce_instance.
   //
   // Try to provide a filter that is selective enough to pick just one TimeSeries for the autoscaled group or for each of the instances (if you are using gce_instance resource type). If multiple TimeSeries are returned upon the query execution, the autoscaler will sum their respective values to obtain its scaling value.
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The identifier (type) of the Stackdriver Monitoring metric. The metric cannot have negative values.
   //
   // The metric must have a value type of INT64 or DOUBLE.
-  optional string metric = 264631728;
+  optional string metric = 533067184;
 
   // If scaling is based on a per-group metric value that represents the total amount of work to be done or resource usage, set this value to an amount assigned for a single instance of the scaled group. Autoscaler keeps the number of instances proportional to the value of this metric. The metric itself does not change value due to group resizing.
   //
   // A good metric to use with the target is for example pubsub.googleapis.com/subscription/num_undelivered_messages or a custom metric exporting the total number of requests coming to your instances.
   //
   // A bad example would be a metric exporting an average or median latency, since this value can't include a chunk assignable to a single instance, it could be better used with utilization_target instead.
-  optional double single_instance_assignment = 236332608;
+  optional double single_instance_assignment = 504768064;
 
   // The target value of the metric that autoscaler maintains. This must be a positive value. A utilization metric scales number of virtual machines handling requests to increase or decrease proportionally to the metric.
   //
@@ -1220,7 +1220,7 @@ message AutoscalingPolicyCustomMetricUtilization {
   optional double utilization_target = 215905870;
 
   // Defines how target utilization value is expressed for a Stackdriver Monitoring metric. Either GAUGE, DELTA_PER_SECOND, or DELTA_PER_MINUTE.
-  optional UtilizationTargetType utilization_target_type = 71733899;
+  optional UtilizationTargetType utilization_target_type = 340169355;
 
 }
 
@@ -1248,13 +1248,13 @@ message FixedOrPercent {
   //
   // - If the value is fixed, then the calculated value is equal to the fixed value.
   // - If the value is a percent, then the calculated value is percent/100 * targetSize. For example, the calculated value of a 80% of a managed instance group with 150 instances would be (80/100 * 150) = 120 VM instances. If there is a remainder, the number is rounded up.
-  optional int32 calculated = 203647422;
+  optional int32 calculated = 472082878;
 
   // Specifies a fixed number of VM instances. This must be a positive integer.
   optional int32 fixed = 97445748;
 
   // Specifies a percentage of instances between 0 to 100%, inclusive. For example, specify 80 for 80%.
-  optional int32 percent = 126379077;
+  optional int32 percent = 394814533;
 
 }
 
@@ -1306,15 +1306,15 @@ message Backend {
   //
   // - If the load balancing mode is UTILIZATION, the load is spread based on the backend utilization of instances in an instance group.
   // You can use the UTILIZATION balancing mode if the loadBalancingScheme of the backend service is EXTERNAL (except Network Load Balancing), INTERNAL_SELF_MANAGED, or INTERNAL_MANAGED and the backends are instance groups. There are no restrictions on the backend service protocol.
-  optional BalancingMode balancing_mode = 161850761;
+  optional BalancingMode balancing_mode = 430286217;
 
   // A multiplier applied to the group's maximum servicing capacity (based on UTILIZATION, RATE or CONNECTION). Default value is 1, which means the group will serve up to 100% of its configured capacity (depending on balancingMode). A setting of 0 means the group is completely drained, offering 0% of its available capacity. Valid range is 0.0 and [0.1,1.0]. You cannot configure a setting larger than 0 and smaller than 0.1. You cannot configure a setting of 0 when there is only one backend attached to the backend service.
   //
   // This cannot be used for Internal TCP/UDP Load Balancing and Network Load Balancing.
-  optional float capacity_scaler = 47522701;
+  optional float capacity_scaler = 315958157;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // This field designates whether this is a failover backend. More than one failover backend can be configured for a given BackendService.
   optional bool failover = 138892530;
@@ -1352,7 +1352,7 @@ message Backend {
   // If the backend's balancingMode is UTILIZATION, this is an optional parameter. If the backend's balancingMode is RATE, you must specify maxRate, maxRatePerInstance, or maxRatePerEndpoint.
   //
   // Not available if the backend's balancingMode is CONNECTION.
-  optional int32 max_rate = 139599579;
+  optional int32 max_rate = 408035035;
 
   // Defines a maximum target for requests per second (RPS) for an endpoint of a NEG. This is multiplied by the number of endpoints in the NEG to implicitly calculate a target maximum rate for the NEG.
   //
@@ -1388,11 +1388,11 @@ message BackendBucketCdnPolicy {
     // A value indicating that the enum field is not set.
     UNDEFINED_CACHE_MODE = 0;
 
-    CACHE_ALL_STATIC = 86592489;
+    CACHE_ALL_STATIC = 355027945;
 
-    FORCE_CACHE_ALL = 217591472;
+    FORCE_CACHE_ALL = 486026928;
 
-    INVALID_CACHE_MODE = 112860104;
+    INVALID_CACHE_MODE = 381295560;
 
     USE_ORIGIN_HEADERS = 55380261;
 
@@ -1414,13 +1414,13 @@ message BackendBucketCdnPolicy {
   optional int32 default_ttl = 100253422;
 
   // Specifies the maximum allowed TTL for cached content served by this origin. Cache directives that attempt to set a max-age or s-maxage higher than this, or an Expires header more than maxTTL seconds in the future will be capped at the value of maxTTL, as if it were the value of an s-maxage Cache-Control directive. Headers sent to the client will not be modified. Setting a TTL of "0" means "always revalidate". The maximum allowed value is 31,622,400s (1 year), noting that infrequently accessed objects may be evicted from the cache before the defined TTL.
-  optional int32 max_ttl = 39142545;
+  optional int32 max_ttl = 307578001;
 
   // Maximum number of seconds the response to a signed URL request will be considered fresh. After this time period, the response will be revalidated before being served. Defaults to 1hr (3600s). When serving responses to signed URL requests, Cloud CDN will internally behave as though all responses from this backend had a "Cache-Control: public, max-age=[TTL]" header, regardless of any existing Cache-Control header. The actual headers served in responses will not be altered.
-  optional string signed_url_cache_max_age_sec = 939078;
+  optional string signed_url_cache_max_age_sec = 269374534;
 
   // [Output Only] Names of the keys for signing request URLs.
-  repeated string signed_url_key_names = 103413429;
+  repeated string signed_url_key_names = 371848885;
 
 }
 
@@ -1429,7 +1429,7 @@ message BackendBucketCdnPolicy {
 // This Cloud Storage bucket resource is referenced by a URL map of a load balancer. For more information, read Backend Buckets.
 message BackendBucket {
   // Cloud Storage bucket name.
-  optional string bucket_name = 15174592;
+  optional string bucket_name = 283610048;
 
   // Cloud CDN configuration for this BackendBucket.
   optional BackendBucketCdnPolicy cdn_policy = 213976452;
@@ -1438,13 +1438,13 @@ message BackendBucket {
   optional string creation_timestamp = 30525366;
 
   // Headers that the HTTP/S load balancer should add to proxied responses.
-  repeated string custom_response_headers = 119103638;
+  repeated string custom_response_headers = 387539094;
 
   // An optional textual description of the resource; provided by the client when the resource is created.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // If true, enable Cloud CDN for this BackendBucket.
-  optional bool enable_cdn = 14506865;
+  optional bool enable_cdn = 282942321;
 
   // [Output Only] Unique identifier for the resource; defined by the server.
   optional string id = 3355;
@@ -1456,7 +1456,7 @@ message BackendBucket {
   optional string name = 3373707;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
 }
 
@@ -1475,7 +1475,7 @@ message BackendBucketList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -1495,11 +1495,11 @@ message BackendServiceCdnPolicy {
     // A value indicating that the enum field is not set.
     UNDEFINED_CACHE_MODE = 0;
 
-    CACHE_ALL_STATIC = 86592489;
+    CACHE_ALL_STATIC = 355027945;
 
-    FORCE_CACHE_ALL = 217591472;
+    FORCE_CACHE_ALL = 486026928;
 
-    INVALID_CACHE_MODE = 112860104;
+    INVALID_CACHE_MODE = 381295560;
 
     USE_ORIGIN_HEADERS = 55380261;
 
@@ -1524,13 +1524,13 @@ message BackendServiceCdnPolicy {
   optional int32 default_ttl = 100253422;
 
   // Specifies the maximum allowed TTL for cached content served by this origin. Cache directives that attempt to set a max-age or s-maxage higher than this, or an Expires header more than maxTTL seconds in the future will be capped at the value of maxTTL, as if it were the value of an s-maxage Cache-Control directive. Headers sent to the client will not be modified. Setting a TTL of "0" means "always revalidate". The maximum allowed value is 31,622,400s (1 year), noting that infrequently accessed objects may be evicted from the cache before the defined TTL.
-  optional int32 max_ttl = 39142545;
+  optional int32 max_ttl = 307578001;
 
   // Maximum number of seconds the response to a signed URL request will be considered fresh. After this time period, the response will be revalidated before being served. Defaults to 1hr (3600s). When serving responses to signed URL requests, Cloud CDN will internally behave as though all responses from this backend had a "Cache-Control: public, max-age=[TTL]" header, regardless of any existing Cache-Control header. The actual headers served in responses will not be altered.
-  optional string signed_url_cache_max_age_sec = 939078;
+  optional string signed_url_cache_max_age_sec = 269374534;
 
   // [Output Only] Names of the keys for signing request URLs.
-  repeated string signed_url_key_names = 103413429;
+  repeated string signed_url_key_names = 371848885;
 
 }
 
@@ -1540,13 +1540,13 @@ message CircuitBreakers {
   optional int32 max_connections = 110652154;
 
   // The maximum number of pending requests allowed to the backend service. If not specified, there is no limit.
-  optional int32 max_pending_requests = 107123431;
+  optional int32 max_pending_requests = 375558887;
 
   // The maximum number of parallel requests that allowed to the backend service. If not specified, there is no limit.
   optional int32 max_requests = 28097599;
 
   // Maximum requests for a single connection to the backend service. This parameter is respected by both the HTTP/1.1 and HTTP/2 implementations. If not specified, there is no limit. Setting this parameter to 1 will effectively disable keep alive.
-  optional int32 max_requests_per_connection = 93195072;
+  optional int32 max_requests_per_connection = 361630528;
 
   // The maximum number of parallel retries allowed to the backend cluster. If not specified, the default is 1.
   optional int32 max_retries = 55546219;
@@ -1594,7 +1594,7 @@ message BackendServiceIAP {
   optional bool enabled = 1018689;
 
   // OAuth2 client ID to use for the authentication flow.
-  optional string oauth2_client_id = 45582155;
+  optional string oauth2_client_id = 314017611;
 
   // OAuth2 client secret to use for the authentication flow. For security reasons, this value cannot be retrieved via the API. Instead, the SHA-256 hash of the value is returned in the oauth2ClientSecretSha256 field.
   optional string oauth2_client_secret = 50999520;
@@ -1607,7 +1607,7 @@ message BackendServiceIAP {
 // The available logging options for the load balancer traffic served by this backend service.
 message BackendServiceLogConfig {
   // This field denotes whether to enable logging for the load balancer traffic served by this backend service.
-  optional bool enable = 43328899;
+  optional bool enable = 311764355;
 
   // This field can only be specified if logging is enabled for this backend service. The value of the field must be in [0, 1]. This configures the sampling rate of requests to the load balancer where 1.0 means all logged requests are reported and 0.0 means no logged requests are reported. The default value is 1.0.
   optional float sample_rate = 153193045;
@@ -1620,16 +1620,16 @@ message OutlierDetection {
   optional Duration base_ejection_time = 80997255;
 
   // Number of errors before a host is ejected from the connection pool. When the backend host is accessed over HTTP, a 5xx return code qualifies as an error. Defaults to 5.
-  optional int32 consecutive_errors = 118757792;
+  optional int32 consecutive_errors = 387193248;
 
   // The number of consecutive gateway failures (502, 503, 504 status or connection errors that are mapped to one of those status codes) before a consecutive gateway failure ejection occurs. Defaults to 3.
-  optional int32 consecutive_gateway_failure = 149068794;
+  optional int32 consecutive_gateway_failure = 417504250;
 
   // The percentage chance that a host will be actually ejected when an outlier status is detected through consecutive 5xx. This setting can be used to disable ejection or to ramp it up slowly. Defaults to 0.
   optional int32 enforcing_consecutive_errors = 213133760;
 
   // The percentage chance that a host will be actually ejected when an outlier status is detected through consecutive gateway failures. This setting can be used to disable ejection or to ramp it up slowly. Defaults to 100.
-  optional int32 enforcing_consecutive_gateway_failure = 126005210;
+  optional int32 enforcing_consecutive_gateway_failure = 394440666;
 
   // The percentage chance that a host will be actually ejected when an outlier status is detected through success rate statistics. This setting can be used to disable ejection or to ramp it up slowly. Defaults to 100.
   optional int32 enforcing_success_rate = 194508732;
@@ -1641,10 +1641,10 @@ message OutlierDetection {
   optional int32 max_ejection_percent = 18436888;
 
   // The number of hosts in a cluster that must have enough request volume to detect success rate outliers. If the number of hosts is less than this setting, outlier detection via success rate statistics is not performed for any host in the cluster. Defaults to 5.
-  optional int32 success_rate_minimum_hosts = 257331447;
+  optional int32 success_rate_minimum_hosts = 525766903;
 
   // The minimum number of total requests that must be collected in one interval (as defined by the interval duration above) to include this host in success rate based outlier detection. If the volume is lower than this setting, outlier detection via success rate statistics is not performed for that host. Defaults to 100.
-  optional int32 success_rate_request_volume = 12989901;
+  optional int32 success_rate_request_volume = 281425357;
 
   // This factor is used to determine the ejection threshold for success rate outlier ejection. The ejection threshold is the difference between the mean success rate, and the product of this factor and the standard deviation of the mean success rate: mean - (stdev * success_rate_stdev_factor). This factor is divided by a thousand to get a double. That is, if the desired factor is 1.9, the runtime value should be 1900. Defaults to 1900.
   optional int32 success_rate_stdev_factor = 174735773;
@@ -1657,13 +1657,13 @@ message SecuritySettings {
   // clientTlsPolicy only applies to a global BackendService with the loadBalancingScheme set to INTERNAL_SELF_MANAGED.
   // If left blank, communications are not encrypted.
   // Note: This field currently has no impact.
-  optional string client_tls_policy = 193889770;
+  optional string client_tls_policy = 462325226;
 
   // Optional. A list of Subject Alternative Names (SANs) that the client verifies during a mutual TLS handshake with an server/endpoint for this BackendService. When the server presents its X.509 certificate to the client, the client inspects the certificate's subjectAltName field. If the field contains one of the specified values, the communication continues. Otherwise, it fails. This additional check enables the client to verify that the server is authorized to run the requested service.
   // Note that the contents of the server certificate's subjectAltName field are configured by the Public Key Infrastructure which provisions server identities.
   // Only applies to a global BackendService with loadBalancingScheme set to INTERNAL_SELF_MANAGED. Only applies when BackendService has an attached clientTlsPolicy with clientCertificate (mTLS mode).
   // Note: This field currently has no impact.
-  repeated string subject_alt_names = 61594079;
+  repeated string subject_alt_names = 330029535;
 
 }
 
@@ -1686,13 +1686,13 @@ message BackendService {
 
     EXTERNAL = 35607499;
 
-    INTERNAL = 10860221;
+    INTERNAL = 279295677;
 
     INTERNAL_MANAGED = 37350397;
 
     INTERNAL_SELF_MANAGED = 236211150;
 
-    INVALID_LOAD_BALANCING_SCHEME = 6916604;
+    INVALID_LOAD_BALANCING_SCHEME = 275352060;
 
   }
 
@@ -1715,7 +1715,7 @@ message BackendService {
     // A value indicating that the enum field is not set.
     UNDEFINED_LOCALITY_LB_POLICY = 0;
 
-    INVALID_LB_POLICY = 54883251;
+    INVALID_LB_POLICY = 323318707;
 
     LEAST_REQUEST = 46604921;
 
@@ -1725,7 +1725,7 @@ message BackendService {
 
     RANDOM = 262527171;
 
-    RING_HASH = 164359613;
+    RING_HASH = 432795069;
 
     ROUND_ROBIN = 153895801;
 
@@ -1769,17 +1769,17 @@ message BackendService {
     // A value indicating that the enum field is not set.
     UNDEFINED_SESSION_AFFINITY = 0;
 
-    CLIENT_IP = 77229595;
+    CLIENT_IP = 345665051;
 
     CLIENT_IP_PORT_PROTO = 221722926;
 
     CLIENT_IP_PROTO = 25322148;
 
-    GENERATED_COOKIE = 101885748;
+    GENERATED_COOKIE = 370321204;
 
     HEADER_FIELD = 200737960;
 
-    HTTP_COOKIE = 226546171;
+    HTTP_COOKIE = 494981627;
 
     NONE = 2402104;
 
@@ -1790,10 +1790,10 @@ message BackendService {
   // If set to 0, the cookie is non-persistent and lasts only until the end of the browser session (or equivalent). The maximum allowed value is one day (86,400).
   //
   // Not supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true.
-  optional int32 affinity_cookie_ttl_sec = 101561498;
+  optional int32 affinity_cookie_ttl_sec = 369996954;
 
   // The list of backends that serve this BackendService.
-  repeated Backend backends = 242404447;
+  repeated Backend backends = 510839903;
 
   // Cloud CDN configuration for this BackendService. Not available for Internal TCP/UDP Load Balancing and Network Load Balancing.
   optional BackendServiceCdnPolicy cdn_policy = 213976452;
@@ -1805,9 +1805,9 @@ message BackendService {
   // - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED.
   //
   // Not supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true.
-  optional CircuitBreakers circuit_breakers = 152904605;
+  optional CircuitBreakers circuit_breakers = 421340061;
 
-  optional ConnectionDraining connection_draining = 192661291;
+  optional ConnectionDraining connection_draining = 461096747;
 
   // Consistent Hash-based load balancing can be used to provide soft session affinity based on HTTP headers, cookies or other properties. This load balancing policy is applicable only for HTTP connections. The affinity to a particular destination host will be lost when one or more hosts are added/removed from the destination service. This field specifies parameters that control consistent hashing. This field is only applicable when localityLbPolicy is set to MAGLEV or RING_HASH.
   //
@@ -1825,10 +1825,10 @@ message BackendService {
   repeated string custom_request_headers = 27977992;
 
   // Headers that the HTTP/S load balancer should add to proxied responses.
-  repeated string custom_response_headers = 119103638;
+  repeated string custom_response_headers = 387539094;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // If true, enables Cloud CDN for the backend service. Only applicable if the loadBalancingScheme is EXTERNAL and the protocol is HTTP or HTTPS.
   optional bool enable_c_d_n = 250733499;
@@ -1842,7 +1842,7 @@ message BackendService {
   optional string fingerprint = 234678500;
 
   // The list of URLs to the healthChecks, httpHealthChecks (legacy), or httpsHealthChecks (legacy) resource for health checking this backend service. Not all backend services support legacy health checks. See  Load balancer guide. Currently, at most one health check can be specified for each backend service. Backend services with instance group or zonal NEG backends must have a health check. Backend services with internet or serverless NEG backends must not have a health check.
-  repeated string health_checks = 179935150;
+  repeated string health_checks = 448370606;
 
   // The configurations for Identity-Aware Proxy on this resource. Not available for Internal TCP/UDP Load Balancing and Network Load Balancing.
   optional BackendServiceIAP iap = 104024;
@@ -1854,7 +1854,7 @@ message BackendService {
   optional string kind = 3292052;
 
   // Specifies the load balancer type. Choose EXTERNAL for external HTTP(S), SSL Proxy, TCP Proxy and Network Load Balancing. Choose  INTERNAL for Internal TCP/UDP Load Balancing. Choose  INTERNAL_MANAGED for Internal HTTP(S) Load Balancing.  INTERNAL_SELF_MANAGED for Traffic Director. A backend service created for one type of load balancer cannot be used with another. For more information, refer to Choosing a load balancer.
-  optional LoadBalancingScheme load_balancing_scheme = 95454788;
+  optional LoadBalancingScheme load_balancing_scheme = 363890244;
 
   // The load balancing algorithm used within the scope of the locality. The possible values are:
   // - ROUND_ROBIN: This is a simple policy in which each healthy backend is selected in round robin order. This is the default.
@@ -1874,7 +1874,7 @@ message BackendService {
   optional LocalityLbPolicy locality_lb_policy = 131431487;
 
   // This field denotes the logging options for the load balancer traffic served by this backend service. If logging is enabled, logs will be exported to Stackdriver.
-  optional BackendServiceLogConfig log_config = 82864285;
+  optional BackendServiceLogConfig log_config = 351299741;
 
   // Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
   optional string name = 3373707;
@@ -1889,7 +1889,7 @@ message BackendService {
   // - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED.
   //
   // Not supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true.
-  optional OutlierDetection outlier_detection = 86189630;
+  optional OutlierDetection outlier_detection = 354625086;
 
   // Deprecated in favor of portName. The TCP port to connect on the backend. The default value is 80.
   //
@@ -1919,10 +1919,10 @@ message BackendService {
   // This field specifies the security policy that applies to this backend service. This field is applicable to either:
   // - A regional backend service with the service_protocol set to HTTP, HTTPS, or HTTP2, and load_balancing_scheme set to INTERNAL_MANAGED.
   // - A global backend service with the load_balancing_scheme set to INTERNAL_SELF_MANAGED.
-  optional SecuritySettings security_settings = 210214466;
+  optional SecuritySettings security_settings = 478649922;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // Type of session affinity to use. The default is NONE.
   //
@@ -1933,7 +1933,7 @@ message BackendService {
   // When the loadBalancingScheme is INTERNAL_SELF_MANAGED, or INTERNAL_MANAGED, possible values are NONE, CLIENT_IP, GENERATED_COOKIE, HEADER_FIELD, or HTTP_COOKIE.
   //
   // Not supported when the backend service is referenced by a URL map that is bound to target gRPC proxy that has validateForProxyless field set to true.
-  optional SessionAffinity session_affinity = 195453105;
+  optional SessionAffinity session_affinity = 463888561;
 
   // The backend service timeout has a different meaning depending on the type of load balancer. For more information see,  Backend service settings The default is 30 seconds.
   optional int32 timeout_sec = 79994995;
@@ -1943,7 +1943,7 @@ message BackendService {
 //
 message BackendServicesScopedList {
   // A list of BackendServices contained in this scope.
-  repeated BackendService backend_services = 120086953;
+  repeated BackendService backend_services = 388522409;
 
   // Informational warning which replaces the list of backend services when the list is empty.
   optional Warning warning = 50704284;
@@ -1965,7 +1965,7 @@ message BackendServiceAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -1978,16 +1978,16 @@ message BackendServiceAggregatedList {
 // Message containing what to include in the cache key for a request for Cloud CDN.
 message CacheKeyPolicy {
   // If true, requests to different hosts will be cached separately.
-  optional bool include_host = 218432223;
+  optional bool include_host = 486867679;
 
   // If true, http and https requests will be cached separately.
-  optional bool include_protocol = 35072079;
+  optional bool include_protocol = 303507535;
 
   // If true, include query string parameters in the cache key according to query_string_whitelist and query_string_blacklist. If neither is set, the entire query string will be included. If false, the query string will be excluded from the cache key entirely.
-  optional bool include_query_string = 205601183;
+  optional bool include_query_string = 474036639;
 
   // Names of query string parameters to exclude in cache keys. All other parameters will be included. Either specify query_string_whitelist or query_string_blacklist, not both. '&' and '=' will be percent encoded and not treated as delimiters.
-  repeated string query_string_blacklist = 86529286;
+  repeated string query_string_blacklist = 354964742;
 
   // Names of query string parameters to include in cache keys. All other parameters will be excluded. Either specify query_string_whitelist or query_string_blacklist, not both. '&' and '=' will be percent encoded and not treated as delimiters.
   repeated string query_string_whitelist = 52456496;
@@ -2001,9 +2001,9 @@ message HealthStatus {
     // A value indicating that the enum field is not set.
     UNDEFINED_HEALTH_STATE = 0;
 
-    HEALTHY = 171365757;
+    HEALTHY = 439801213;
 
-    UNHEALTHY = 193682628;
+    UNHEALTHY = 462118084;
 
   }
 
@@ -2012,13 +2012,13 @@ message HealthStatus {
     // A value indicating that the enum field is not set.
     UNDEFINED_WEIGHT_ERROR = 0;
 
-    INVALID_WEIGHT = 115262944;
+    INVALID_WEIGHT = 383698400;
 
-    MISSING_WEIGHT = 115592081;
+    MISSING_WEIGHT = 384027537;
 
-    UNAVAILABLE_WEIGHT = 171028839;
+    UNAVAILABLE_WEIGHT = 439464295;
 
-    WEIGHT_NONE = 233993375;
+    WEIGHT_NONE = 502428831;
 
   }
 
@@ -2026,20 +2026,20 @@ message HealthStatus {
   map<string, string> annotations = 112032548;
 
   // Health state of the instance.
-  optional HealthState health_state = 55571694;
+  optional HealthState health_state = 324007150;
 
   // URL of the instance resource.
   optional string instance = 18257045;
 
   // A forwarding rule IP address assigned to this instance.
-  optional string ip_address = 137836764;
+  optional string ip_address = 406272220;
 
   // The named port of the instance group, not necessarily the port that is health-checked.
   optional int32 port = 3446913;
 
-  optional string weight = 13714040;
+  optional string weight = 282149496;
 
-  optional WeightError weight_error = 254066049;
+  optional WeightError weight_error = 522501505;
 
 }
 
@@ -2049,7 +2049,7 @@ message BackendServiceGroupHealth {
   map<string, string> annotations = 112032548;
 
   // Health state of the backend instances or endpoints in requested instance or network endpoint group, determined based on configured health checks.
-  repeated HealthStatus health_status = 112110389;
+  repeated HealthStatus health_status = 380545845;
 
   // [Output Only] Type of resource. Always compute#backendServiceGroupHealth for the health of backend services.
   optional string kind = 3292052;
@@ -2071,7 +2071,7 @@ message BackendServiceList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -2080,7 +2080,7 @@ message BackendServiceList {
 
 //
 message BackendServiceReference {
-  optional string backend_service = 38510602;
+  optional string backend_service = 306946058;
 
 }
 
@@ -2105,13 +2105,13 @@ message BackendServiceReference {
 // The exact variables and functions that may be referenced within an expression are determined by the service that evaluates it. See the service documentation for additional information.
 message Expr {
   // Optional. Description of the expression. This is a longer text which describes the expression, e.g. when hovered over it in a UI.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Textual representation of an expression in Common Expression Language syntax.
-  optional string expression = 83595928;
+  optional string expression = 352031384;
 
   // Optional. String indicating the location of the expression for error reporting, e.g. a file name and a position in the file.
-  optional string location = 21995445;
+  optional string location = 290430901;
 
   // Optional. Title for the expression, i.e. a short string describing its purpose. This can be used e.g. in UIs which allow to enter the expression.
   optional string title = 110371416;
@@ -2120,7 +2120,7 @@ message Expr {
 
 // Associates `members` with a `role`.
 message Binding {
-  optional string binding_id = 172652821;
+  optional string binding_id = 441088277;
 
   // The condition that is associated with this binding.
   //
@@ -2154,7 +2154,7 @@ message Binding {
   //
   //
   // * `domain:{domain}`: The G Suite domain (primary) that represents all the users of that domain. For example, `google.com` or `example.com`.
-  repeated string members = 143575321;
+  repeated string members = 412010777;
 
   // Role that is assigned to `members`. For example, `roles/viewer`, `roles/editor`, or `roles/owner`.
   optional string role = 3506294;
@@ -2190,26 +2190,26 @@ message Reservation {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    CREATING = 187129529;
+    CREATING = 455564985;
 
-    DELETING = 260166568;
+    DELETING = 528602024;
 
-    INVALID = 261848535;
+    INVALID = 530283991;
 
     READY = 77848963;
 
-    UPDATING = 226178886;
+    UPDATING = 494614342;
 
   }
 
   // [Output Only] Full or partial URL to a parent commitment. This field displays for reservations that are tied to a commitment.
-  optional string commitment = 213699349;
+  optional string commitment = 482134805;
 
   // [Output Only] Creation timestamp in RFC3339 text format.
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -2221,10 +2221,10 @@ message Reservation {
   optional string name = 3373707;
 
   // [Output Only] Server-defined fully-qualified URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // Reservation for instances with specific machine shapes.
-  optional AllocationSpecificSKUReservation specific_reservation = 136466495;
+  optional AllocationSpecificSKUReservation specific_reservation = 404901951;
 
   // Indicates whether the reservation can be consumed by VMs with affinity for "any" reservation. If the field is set, then only VMs that target the reservation by name can consume from this reservation.
   optional bool specific_reservation_required = 226550687;
@@ -2244,13 +2244,13 @@ message ResourceCommitment {
     // A value indicating that the enum field is not set.
     UNDEFINED_TYPE = 0;
 
-    ACCELERATOR = 161379915;
+    ACCELERATOR = 429815371;
 
-    LOCAL_SSD = 240499440;
+    LOCAL_SSD = 508934896;
 
     MEMORY = 123056385;
 
-    UNSPECIFIED = 258350871;
+    UNSPECIFIED = 526786327;
 
     VCPU = 2628978;
 
@@ -2276,11 +2276,11 @@ message Commitment {
     // A value indicating that the enum field is not set.
     UNDEFINED_CATEGORY = 0;
 
-    CATEGORY_UNSPECIFIED = 240754006;
+    CATEGORY_UNSPECIFIED = 509189462;
 
-    LICENSE = 79433761;
+    LICENSE = 347869217;
 
-    MACHINE = 201117735;
+    MACHINE = 469553191;
 
   }
 
@@ -2289,7 +2289,7 @@ message Commitment {
     // A value indicating that the enum field is not set.
     UNDEFINED_PLAN = 0;
 
-    INVALID = 261848535;
+    INVALID = 530283991;
 
     THIRTY_SIX_MONTH = 266295942;
 
@@ -2302,11 +2302,11 @@ message Commitment {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    ACTIVE = 46297862;
+    ACTIVE = 314733318;
 
-    CREATING = 187129529;
+    CREATING = 455564985;
 
-    EXPIRED = 214053637;
+    EXPIRED = 482489093;
 
     NOT_YET_ACTIVE = 20607337;
 
@@ -2319,10 +2319,10 @@ message Commitment {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] Commitment end time in RFC3339 text format.
-  optional string end_timestamp = 199661234;
+  optional string end_timestamp = 468096690;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -2331,7 +2331,7 @@ message Commitment {
   optional string kind = 3292052;
 
   // The license specification required as part of a license commitment.
-  optional LicenseResourceCommitment license_resource = 169519692;
+  optional LicenseResourceCommitment license_resource = 437955148;
 
   // Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
   optional string name = 3373707;
@@ -2343,13 +2343,13 @@ message Commitment {
   optional string region = 138946292;
 
   // List of reservations in this commitment.
-  repeated Reservation reservations = 131282471;
+  repeated Reservation reservations = 399717927;
 
   // A list of commitment amounts for particular resources. Note that VCPU and MEMORY resource commitments must occur together.
   repeated ResourceCommitment resources = 164412965;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Commitment start time in RFC3339 text format.
   optional string start_timestamp = 83645817;
@@ -2358,14 +2358,14 @@ message Commitment {
   optional Status status = 181260274;
 
   // [Output Only] An optional, human-readable explanation of the status.
-  optional string status_message = 28992698;
+  optional string status_message = 297428154;
 
 }
 
 //
 message CommitmentsScopedList {
   // [Output Only] A list of commitments contained in this scope.
-  repeated Commitment commitments = 182228990;
+  repeated Commitment commitments = 450664446;
 
   // [Output Only] Informational warning which replaces the list of commitments when the list is empty.
   optional Warning warning = 50704284;
@@ -2387,7 +2387,7 @@ message CommitmentAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -2412,7 +2412,7 @@ message CommitmentList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -2464,7 +2464,7 @@ message Duration {
   optional int32 nanos = 104586303;
 
   // Span of time at a resolution of a second. Must be from 0 to 315,576,000,000 inclusive. Note: these bounds are computed from: 60 sec/min * 60 min/hr * 24 hr/day * 365.25 days/year * 10000 years
-  optional string seconds = 91048575;
+  optional string seconds = 359484031;
 
 }
 
@@ -2472,7 +2472,7 @@ message Duration {
 message CorsPolicy {
   // In response to a preflight request, setting this to true indicates that the actual request can include user credentials. This translates to the Access-Control-Allow-Credentials header.
   // Default is false.
-  optional bool allow_credentials = 212827910;
+  optional bool allow_credentials = 481263366;
 
   // Specifies the content for the Access-Control-Allow-Headers header.
   repeated string allow_headers = 45179024;
@@ -2489,20 +2489,20 @@ message CorsPolicy {
   repeated string allow_origins = 194914071;
 
   // If true, specifies the CORS policy is disabled. The default value of false, which indicates that the CORS policy is in effect.
-  optional bool disabled = 2505340;
+  optional bool disabled = 270940796;
 
   // Specifies the content for the Access-Control-Expose-Headers header.
   repeated string expose_headers = 247604747;
 
   // Specifies how long results of a preflight request can be cached in seconds. This translates to the Access-Control-Max-Age header.
-  optional int32 max_age = 39123876;
+  optional int32 max_age = 307559332;
 
 }
 
 //
 message CustomerEncryptionKeyProtectedDisk {
   // Decrypts data associated with the disk with a customer-supplied encryption key.
-  optional CustomerEncryptionKey disk_encryption_key = 3225221;
+  optional CustomerEncryptionKey disk_encryption_key = 271660677;
 
   // Specifies a valid partial or full URL to an existing Persistent Disk resource. This field is only applicable for persistent disks.
   optional string source = 177235995;
@@ -2526,15 +2526,15 @@ message Disk {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    CREATING = 187129529;
+    CREATING = 455564985;
 
-    DELETING = 260166568;
+    DELETING = 528602024;
 
-    FAILED = 187271229;
+    FAILED = 455706685;
 
     READY = 77848963;
 
-    RESTORING = 135828395;
+    RESTORING = 404263851;
 
   }
 
@@ -2542,7 +2542,7 @@ message Disk {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Encrypts the disk using a customer-supplied encryption key.
   //
@@ -2551,7 +2551,7 @@ message Disk {
   // Customer-supplied encryption keys do not protect access to metadata of the disk.
   //
   // If you do not provide an encryption key when creating the disk, then the disk will be encrypted using an automatically generated key and you do not need to provide a key to use the disk later.
-  optional CustomerEncryptionKey disk_encryption_key = 3225221;
+  optional CustomerEncryptionKey disk_encryption_key = 271660677;
 
   // A list of features to enable on the guest operating system. Applicable only for bootable images. Read  Enabling guest operating system features to see a list of available options.
   repeated GuestOsFeature guest_os_features = 79294545;
@@ -2568,7 +2568,7 @@ message Disk {
   optional string label_fingerprint = 178124825;
 
   // Labels to apply to this disk. These can be later modified by the setLabels method.
-  map<string, string> labels = 231759871;
+  map<string, string> labels = 500195327;
 
   // [Output Only] Last attach timestamp in RFC3339 text format.
   optional string last_attach_timestamp = 42159653;
@@ -2580,16 +2580,16 @@ message Disk {
   repeated string license_codes = 45482664;
 
   // A list of publicly visible licenses. Reserved for Google's use.
-  repeated string licenses = 69207122;
+  repeated string licenses = 337642578;
 
   // Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
   optional string name = 3373707;
 
   // Internal use only.
-  optional string options = 92702366;
+  optional string options = 361137822;
 
   // Physical block size of the persistent disk, in bytes. If not present in a request, a default value is used. The currently supported size is 4096, other sizes may be added in the future. If an unsupported value is requested, the error message will list the supported values for the caller's project.
-  optional string physical_block_size_bytes = 151572487;
+  optional string physical_block_size_bytes = 420007943;
 
   // [Output Only] URL of the region where the disk resides. Only applicable for regional resources. You must specify this field as part of the HTTP request URL. It is not settable as a field in the request body.
   optional string region = 138946292;
@@ -2601,21 +2601,21 @@ message Disk {
   repeated string resource_policies = 22220385;
 
   // [Output Only] Server-defined fully-qualified URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // Size, in GB, of the persistent disk. You can specify this field when creating a persistent disk using the sourceImage, sourceSnapshot, or sourceDisk parameter, or specify it alone to create an empty persistent disk.
   //
   // If you specify this field along with a source, the value of sizeGb must not be less than the size of the source. Acceptable values are 1 to 65536, inclusive.
-  optional string size_gb = 226493913;
+  optional string size_gb = 494929369;
 
   // The source disk used to create this disk. You can provide this as a partial or full URL to the resource. For example, the following are valid values:
   // - https://www.googleapis.com/compute/v1/projects/project/zones/zone/disks/disk
   // - projects/project/zones/zone/disks/disk
   // - zones/zone/disks/disk
-  optional string source_disk = 183318337;
+  optional string source_disk = 451753793;
 
   // [Output Only] The unique ID of the disk used to create this disk. This value identifies the exact disk that was used to create this persistent disk. For example, if you created the persistent disk from a disk that was later deleted and recreated under the same name, the source disk ID would identify the exact version of the disk that was used.
-  optional string source_disk_id = 185755353;
+  optional string source_disk_id = 454190809;
 
   // The source image used to create this disk. If the source image is deleted, this field will not be set.
   //
@@ -2636,7 +2636,7 @@ message Disk {
   optional string source_image = 50443319;
 
   // The customer-supplied encryption key of the source image. Required if the source image is protected by a customer-supplied encryption key.
-  optional CustomerEncryptionKey source_image_encryption_key = 113068203;
+  optional CustomerEncryptionKey source_image_encryption_key = 381503659;
 
   // [Output Only] The ID value of the image used to create this disk. This value identifies the exact image that was used to create this persistent disk. For example, if you created the persistent disk from an image that was later deleted and recreated under the same name, the source image ID would identify the exact version of the image that was used.
   optional string source_image_id = 55328291;
@@ -2648,7 +2648,7 @@ message Disk {
   optional string source_snapshot = 126061928;
 
   // The customer-supplied encryption key of the source snapshot. Required if the source snapshot is protected by a customer-supplied encryption key.
-  optional CustomerEncryptionKey source_snapshot_encryption_key = 35243866;
+  optional CustomerEncryptionKey source_snapshot_encryption_key = 303679322;
 
   // [Output Only] The unique ID of the snapshot used to create this disk. This value identifies the exact snapshot that was used to create this persistent disk. For example, if you created the persistent disk from a snapshot that was later deleted and recreated under the same name, the source snapshot ID would identify the exact version of the snapshot that was used.
   optional string source_snapshot_id = 98962258;
@@ -2692,7 +2692,7 @@ message DiskAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -2714,7 +2714,7 @@ message DiskInstantiationConfig {
     // A value indicating that the enum field is not set.
     UNDEFINED_INSTANTIATE_FROM = 0;
 
-    ATTACH_READ_ONLY = 245339963;
+    ATTACH_READ_ONLY = 513775419;
 
     BLANK = 63281460;
 
@@ -2731,7 +2731,7 @@ message DiskInstantiationConfig {
   }
 
   // Specifies whether the disk will be auto-deleted when the instance is deleted (but not when the disk is detached from the instance).
-  optional bool auto_delete = 196325947;
+  optional bool auto_delete = 464761403;
 
   // The custom source image to be used to restore this disk when instantiating this instance template.
   optional string custom_image = 184123149;
@@ -2745,7 +2745,7 @@ message DiskInstantiationConfig {
   // - custom-image: to use a user-provided image url for disk creation. Applicable to the boot disk and additional read-write disks.
   // - attach-read-only: to attach a read-only disk. Applicable to read-only disks.
   // - do-not-include: to exclude a disk from the template. Applicable to additional read-write disks, local SSDs, and read-only disks.
-  optional InstantiateFrom instantiate_from = 124948447;
+  optional InstantiateFrom instantiate_from = 393383903;
 
 }
 
@@ -2764,7 +2764,7 @@ message DiskList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -2803,13 +2803,13 @@ message DiskType {
   optional string creation_timestamp = 30525366;
 
   // [Output Only] Server-defined default disk size in GB.
-  optional string default_disk_size_gb = 2183797;
+  optional string default_disk_size_gb = 270619253;
 
   // [Output Only] The deprecation status associated with this disk type.
-  optional DeprecationStatus deprecated = 246703539;
+  optional DeprecationStatus deprecated = 515138995;
 
   // [Output Only] An optional description of this resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -2824,10 +2824,10 @@ message DiskType {
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] An optional textual description of the valid disk size, such as "10GB-10TB".
-  optional string valid_disk_size = 225527008;
+  optional string valid_disk_size = 493962464;
 
   // [Output Only] URL of the zone where the disk type resides. You must specify this field as part of the HTTP request URL. It is not settable as a field in the request body.
   optional string zone = 3744684;
@@ -2859,7 +2859,7 @@ message DiskTypeAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -2884,7 +2884,7 @@ message DiskTypeList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -2908,7 +2908,7 @@ message DisksRemoveResourcePoliciesRequest {
 //
 message DisksResizeRequest {
   // The new size of the persistent disk, which is specified in GB.
-  optional string size_gb = 226493913;
+  optional string size_gb = 494929369;
 
 }
 
@@ -2940,16 +2940,16 @@ message ExchangedPeeringRoute {
     // A value indicating that the enum field is not set.
     UNDEFINED_TYPE = 0;
 
-    DYNAMIC_PEERING_ROUTE = 201359402;
+    DYNAMIC_PEERING_ROUTE = 469794858;
 
-    STATIC_PEERING_ROUTE = 204972089;
+    STATIC_PEERING_ROUTE = 473407545;
 
-    SUBNET_PEERING_ROUTE = 197347048;
+    SUBNET_PEERING_ROUTE = 465782504;
 
   }
 
   // The destination range of the route.
-  optional string dest_range = 112892256;
+  optional string dest_range = 381327712;
 
   // True if the peering route has been imported from a peer. The actual import happens if the field networkPeering.importCustomRoutes is true for this network, and networkPeering.exportCustomRoutes is true for the peer network, and the import does not result in a route conflict.
   optional bool imported = 114502404;
@@ -2958,7 +2958,7 @@ message ExchangedPeeringRoute {
   optional string next_hop_region = 122577014;
 
   // The priority of the peering route.
-  optional uint32 priority = 176716196;
+  optional uint32 priority = 445151652;
 
   // The type of the peering route.
   optional Type type = 3575610;
@@ -2980,7 +2980,7 @@ message ExchangedPeeringRoutesList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -2993,7 +2993,7 @@ message ExternalVpnGatewayInterface {
   optional uint32 id = 3355;
 
   // IP address of the interface in the external VPN gateway. Only IPv4 is supported. This IP address can be either from your on-premise gateway or another Cloud provider's VPN gateway, it cannot be an IP address from Google Compute Engine.
-  optional string ip_address = 137836764;
+  optional string ip_address = 406272220;
 
 }
 
@@ -3010,11 +3010,11 @@ message ExternalVpnGateway {
     // A value indicating that the enum field is not set.
     UNDEFINED_REDUNDANCY_TYPE = 0;
 
-    FOUR_IPS_REDUNDANCY = 251652457;
+    FOUR_IPS_REDUNDANCY = 520087913;
 
     SINGLE_IP_INTERNALLY_REDUNDANT = 133914873;
 
-    TWO_IPS_REDUNDANCY = 98614179;
+    TWO_IPS_REDUNDANCY = 367049635;
 
   }
 
@@ -3022,7 +3022,7 @@ message ExternalVpnGateway {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -3039,16 +3039,16 @@ message ExternalVpnGateway {
   optional string label_fingerprint = 178124825;
 
   // Labels for this resource. These can only be added or modified by the setLabels method. Each label key/value pair must comply with RFC1035. Label values may be empty.
-  map<string, string> labels = 231759871;
+  map<string, string> labels = 500195327;
 
   // Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
   optional string name = 3373707;
 
   // Indicates the user-supplied redundancy type of this external VPN gateway.
-  optional RedundancyType redundancy_type = 3008284;
+  optional RedundancyType redundancy_type = 271443740;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
 }
 
@@ -3069,7 +3069,7 @@ message ExternalVpnGatewayList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -3092,17 +3092,17 @@ message FileContentBuffer {
   }
 
   // The raw content in the secure keys file.
-  optional string content = 146224249;
+  optional string content = 414659705;
 
   // The file type of source file.
-  optional FileType file_type = 25911325;
+  optional FileType file_type = 294346781;
 
 }
 
 //
 message Allowed {
   // The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-  optional string i_p_protocol = 55338781;
+  optional string i_p_protocol = 323774237;
 
   // An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
   //
@@ -3114,7 +3114,7 @@ message Allowed {
 //
 message Denied {
   // The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, ipip, sctp) or the IP protocol number.
-  optional string i_p_protocol = 55338781;
+  optional string i_p_protocol = 323774237;
 
   // An optional list of ports to which this rule applies. This field is only applicable for the UDP or TCP protocol. Each entry must be either an integer or a range. If not specified, this rule applies to connections through any port.
   //
@@ -3130,14 +3130,14 @@ message FirewallLogConfig {
     // A value indicating that the enum field is not set.
     UNDEFINED_METADATA = 0;
 
-    EXCLUDE_ALL_METADATA = 66084498;
+    EXCLUDE_ALL_METADATA = 334519954;
 
     INCLUDE_ALL_METADATA = 164619908;
 
   }
 
   // This field denotes whether to enable logging for a particular firewall rule.
-  optional bool enable = 43328899;
+  optional bool enable = 311764355;
 
   // This field can only be specified for a particular firewall rule if logging is enabled for that rule. This field denotes whether to include or exclude metadata for firewall logs.
   optional Metadata metadata = 86866735;
@@ -3153,9 +3153,9 @@ message Firewall {
     // A value indicating that the enum field is not set.
     UNDEFINED_DIRECTION = 0;
 
-    EGRESS = 164445045;
+    EGRESS = 432880501;
 
-    INGRESS = 248495765;
+    INGRESS = 516931221;
 
   }
 
@@ -3166,19 +3166,19 @@ message Firewall {
   optional string creation_timestamp = 30525366;
 
   // The list of DENY rules specified by this firewall. Each rule specifies a protocol and port-range tuple that describes a denied connection.
-  repeated Denied denied = 6781851;
+  repeated Denied denied = 275217307;
 
   // An optional description of this resource. Provide this field when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // If destination ranges are specified, the firewall rule applies only to traffic that has destination IP address in these ranges. These ranges must be expressed in CIDR format. Only IPv4 is supported.
-  repeated string destination_ranges = 37264423;
+  repeated string destination_ranges = 305699879;
 
   // Direction of traffic to which this firewall applies, either `INGRESS` or `EGRESS`. The default is `INGRESS`. For `INGRESS` traffic, you cannot specify the destinationRanges field, and for `EGRESS` traffic, you cannot specify the sourceRanges or sourceTags fields.
   optional Direction direction = 111150975;
 
   // Denotes whether the firewall rule is disabled. When set to true, the firewall rule is not enforced and the network behaves as if it did not exist. If this is unspecified, the firewall rule will be enabled.
-  optional bool disabled = 2505340;
+  optional bool disabled = 270940796;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -3187,7 +3187,7 @@ message Firewall {
   optional string kind = 3292052;
 
   // This field denotes the logging options for a particular firewall rule. If logging is enabled, logs will be exported to Cloud Logging.
-  optional FirewallLogConfig log_config = 82864285;
+  optional FirewallLogConfig log_config = 351299741;
 
   // Name of the resource; provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?. The first character must be a lowercase letter, and all following characters (except for the last character) must be a dash, lowercase letter, or digit. The last character must be a lowercase letter or digit.
   optional string name = 3373707;
@@ -3201,10 +3201,10 @@ message Firewall {
   optional string network = 232872494;
 
   // Priority for this rule. This is an integer between `0` and `65535`, both inclusive. The default value is `1000`. Relative priorities determine which rule takes effect if multiple rules apply. Lower values indicate higher priority. For example, a rule with priority `0` has higher precedence than a rule with priority `1`. DENY rules take precedence over ALLOW rules if they have equal priority. Note that VPC networks have implied rules with a priority of `65535`. To avoid conflicts with the implied rules, use a priority number less than `65535`.
-  optional int32 priority = 176716196;
+  optional int32 priority = 445151652;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // If source ranges are specified, the firewall rule applies only to traffic that has a source IP address in these ranges. These ranges must be expressed in CIDR format. One or both of sourceRanges and sourceTags may be set. If both fields are set, the rule applies to traffic that has a source IP address within sourceRanges OR a source IP from a resource with a matching tag listed in the sourceTags field. The connection does not need to match both fields for the rule to apply. Only IPv4 is supported.
   repeated string source_ranges = 200097658;
@@ -3213,10 +3213,10 @@ message Firewall {
   repeated string source_service_accounts = 105100756;
 
   // If source tags are specified, the firewall rule applies only to traffic with source IPs that match the primary network interfaces of VM instances that have the tag and are in the same VPC network. Source tags cannot be used to control traffic to an instance's external IP address, it only applies to traffic between instances in the same virtual network. Because tags are associated with instances, not IP addresses. One or both of sourceRanges and sourceTags may be set. If both fields are set, the firewall applies to traffic that has a source IP address within sourceRanges OR a source IP from a resource with a matching tag listed in the sourceTags field. The connection does not need to match both fields for the firewall to apply.
-  repeated string source_tags = 183786941;
+  repeated string source_tags = 452222397;
 
   // A list of service accounts indicating sets of instances located in the network that may make network connections as specified in allowed[]. targetServiceAccounts cannot be used at the same time as targetTags or sourceTags. If neither targetServiceAccounts nor targetTags are specified, the firewall rule applies to all instances on the specified network.
-  repeated string target_service_accounts = 189204254;
+  repeated string target_service_accounts = 457639710;
 
   // A list of tags that controls which instances the firewall rule applies to. If targetTags are specified, then the firewall rule applies only to instances in the VPC network that have one of those tags. If no targetTags are specified, the firewall rule applies to all instances on the specified network.
   repeated string target_tags = 62901767;
@@ -3238,7 +3238,7 @@ message FirewallList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -3267,7 +3267,7 @@ message MetadataFilter {
 
   // The list of label value pairs that must match labels in the provided metadata based on filterMatchCriteria
   // This list must not be empty and can have at the most 64 entries.
-  repeated MetadataFilterLabelMatch filter_labels = 39467686;
+  repeated MetadataFilterLabelMatch filter_labels = 307903142;
 
   // Specifies how individual filterLabel matches within the list of filterLabels contribute towards the overall metadataFilter match.
   // Supported values are:
@@ -3352,13 +3352,13 @@ message ForwardingRule {
 
     EXTERNAL = 35607499;
 
-    INTERNAL = 10860221;
+    INTERNAL = 279295677;
 
     INTERNAL_MANAGED = 37350397;
 
     INTERNAL_SELF_MANAGED = 236211150;
 
-    INVALID = 261848535;
+    INVALID = 530283991;
 
   }
 
@@ -3371,28 +3371,28 @@ message ForwardingRule {
     // A value indicating that the enum field is not set.
     UNDEFINED_NETWORK_TIER = 0;
 
-    PREMIUM = 131095095;
+    PREMIUM = 399530551;
 
-    STANDARD = 216207037;
+    STANDARD = 484642493;
 
   }
 
   // This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
   //
   // When the load balancing scheme is INTERNAL and protocol is TCP/UDP, specify this field to allow packets addressed to any ports will be forwarded to the backends configured with this forwarding rule.
-  optional bool all_ports = 176740340;
+  optional bool all_ports = 445175796;
 
   // This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. If the field is set to TRUE, clients can access ILB from all regions. Otherwise only allows access from clients in the same region as the internal load balancer.
-  optional bool allow_global_access = 230974218;
+  optional bool allow_global_access = 499409674;
 
   // Identifies the backend service to which the forwarding rule sends traffic. Required for Internal TCP/UDP Load Balancing and Network Load Balancing; must be omitted for all other load balancer types.
-  optional string backend_service = 38510602;
+  optional string backend_service = 306946058;
 
   // [Output Only] Creation timestamp in RFC3339 text format.
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Fingerprint of this resource. A hash of the contents stored in this object. This field is used in optimistic locking. This field will be ignored when inserting a ForwardingRule. Include the fingerprint in patch request to ensure that you do not overwrite changes that were applied from another concurrent request.
   //
@@ -3414,7 +3414,7 @@ message ForwardingRule {
   // Must be set to `0.0.0.0` when the target is targetGrpcProxy that has validateForProxyless field set to true.
   //
   // For Private Service Connect forwarding rules that forward traffic to Google APIs, IP address must be provided.
-  optional string i_p_address = 254156495;
+  optional string i_p_address = 522591951;
 
   // The IP protocol to which this rule applies.
   //
@@ -3426,13 +3426,13 @@ message ForwardingRule {
   // - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
   // - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
   // - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-  optional IPProtocol i_p_protocol = 55338781;
+  optional IPProtocol i_p_protocol = 323774237;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
 
   // The IP Version that will be used by this forwarding rule. Valid options are IPV4 or IPV6. This can only be specified for an external global forwarding rule.
-  optional IpVersion ip_version = 26524096;
+  optional IpVersion ip_version = 294959552;
 
   // Indicates whether or not this load balancer can be used as a collector for packet mirroring. To prevent mirroring loops, instances behind this load balancer will not have their traffic mirrored even if a PacketMirroring rule applies to them. This can only be set to true for load balancers that have their loadBalancingScheme set to INTERNAL.
   optional bool is_mirroring_collector = 119255164;
@@ -3456,13 +3456,13 @@ message ForwardingRule {
   // - Traffic Director
   //
   // For more information about forwarding rules, refer to Forwarding rule concepts.
-  optional LoadBalancingScheme load_balancing_scheme = 95454788;
+  optional LoadBalancingScheme load_balancing_scheme = 363890244;
 
   // Opaque filter criteria used by Loadbalancer to restrict routing configuration to a limited set of xDS compliant clients. In their xDS requests to Loadbalancer, xDS clients present node metadata. When there is a match, the relevant configuration is made available to those proxies. Otherwise, all the resources (e.g. TargetHttpProxy, UrlMap) referenced by the ForwardingRule will not be visible to those proxies.
   // For each metadataFilter in this list, if its filterMatchCriteria is set to MATCH_ANY, at least one of the filterLabels must match the corresponding label provided in the metadata. If its filterMatchCriteria is set to MATCH_ALL, then all of its filterLabels must match with corresponding labels provided in the metadata. If multiple metadataFilters are specified, all of them need to be satisfied in order to be considered a match.
   // metadataFilters specified here will be applifed before those specified in the UrlMap that this ForwardingRule references.
   // metadataFilters only applies to Loadbalancers that have their loadBalancingScheme set to INTERNAL_SELF_MANAGED.
-  repeated MetadataFilter metadata_filters = 196290283;
+  repeated MetadataFilter metadata_filters = 464725739;
 
   // Name of the resource; provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
   optional string name = 3373707;
@@ -3479,7 +3479,7 @@ message ForwardingRule {
   // For regional ForwardingRule, the valid values are PREMIUM and STANDARD. For GlobalForwardingRule, the valid value is PREMIUM.
   //
   // If this field is not specified, it is assumed to be PREMIUM. If IPAddress is specified, this value must be equal to the networkTier of the Address.
-  optional NetworkTier network_tier = 248962387;
+  optional NetworkTier network_tier = 517397843;
 
   // This field can be used only if: * Load balancing scheme is one of EXTERNAL,  INTERNAL_SELF_MANAGED or INTERNAL_MANAGED, and * IPProtocol is one of TCP, UDP, or SCTP.
   //
@@ -3509,26 +3509,26 @@ message ForwardingRule {
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // An optional prefix to the service name for this Forwarding Rule. If specified, the prefix is the first label of the fully qualified service name.
   //
   // The label must be 1-63 characters long, and comply with RFC1035. Specifically, the label must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
   //
   // This field is only used for internal load balancing.
-  optional string service_label = 148573418;
+  optional string service_label = 417008874;
 
   // [Output Only] The internal fully qualified service name for this Forwarding Rule.
   //
   // This field is only used for internal load balancing.
-  optional string service_name = 91444693;
+  optional string service_name = 359880149;
 
   // This field is only used for internal load balancing.
   //
   // For internal load balancing, this field identifies the subnetwork that the load balanced IP should belong to for this Forwarding Rule.
   //
   // If the network specified is in auto subnet mode, this field is optional. However, if the network is in custom subnet mode, a subnetwork must be specified.
-  optional string subnetwork = 39392238;
+  optional string subnetwork = 307827694;
 
   // The URL of the target resource to receive the matched traffic. For regional forwarding rules, this target must be in the same region as the forwarding rule. For global forwarding rules, this target must be a global load balancing resource. The forwarded traffic must be of a type appropriate to the target object. For more information, see the "Target" column in [Port specifications](/load-balancing/docs/forwarding-rule-concepts#ip_address_specifications).
   //
@@ -3544,7 +3544,7 @@ message ForwardingRule {
 //
 message ForwardingRulesScopedList {
   // A list of forwarding rules contained in this scope.
-  repeated ForwardingRule forwarding_rules = 47385909;
+  repeated ForwardingRule forwarding_rules = 315821365;
 
   // Informational warning which replaces the list of forwarding rules when the list is empty.
   optional Warning warning = 50704284;
@@ -3566,7 +3566,7 @@ message ForwardingRuleAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -3591,7 +3591,7 @@ message ForwardingRuleList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -3600,7 +3600,7 @@ message ForwardingRuleList {
 
 //
 message ForwardingRuleReference {
-  optional string forwarding_rule = 1528574;
+  optional string forwarding_rule = 269964030;
 
 }
 
@@ -3619,9 +3619,9 @@ message GRPCHealthCheck {
 
     USE_FIXED_PORT = 190235748;
 
-    USE_NAMED_PORT = 80865215;
+    USE_NAMED_PORT = 349300671;
 
-    USE_SERVING_PORT = 94202060;
+    USE_SERVING_PORT = 362637516;
 
   }
 
@@ -3662,7 +3662,7 @@ message NetworkEndpoint {
   optional string instance = 18257045;
 
   // Optional IPv4 address of network endpoint. The IP address must belong to a VM in Compute Engine (either the primary IP or as part of an aliased IP range). If the IP address is not specified, then the primary IP address for the VM instance in the network that the network endpoint group belongs to will be used.
-  optional string ip_address = 137836764;
+  optional string ip_address = 406272220;
 
   // Optional port number of network endpoint. If not specified and the NetworkEndpointGroup.network_endpoint_type is GCE_IP_PORT, the defaultPort for the network endpoint group will be used.
   optional int32 port = 3446913;
@@ -3689,7 +3689,7 @@ message GlobalSetLabelsRequest {
   optional string label_fingerprint = 178124825;
 
   // A list of labels to apply for this resource. Each label key & value must comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash. For example, "webserver-frontend": "images". A label value can also be empty (e.g. "my-label": "").
-  map<string, string> labels = 231759871;
+  map<string, string> labels = 500195327;
 
 }
 
@@ -3712,17 +3712,17 @@ message GlobalSetLabelsRequest {
 // For a description of IAM and its features, see the [IAM documentation](https://cloud.google.com/iam/docs/).
 message Policy {
   // Specifies cloud audit logging configuration for this policy.
-  repeated AuditConfig audit_configs = 59645197;
+  repeated AuditConfig audit_configs = 328080653;
 
   // Associates a list of `members` to a `role`. Optionally, may specify a `condition` that determines how and when the `bindings` are applied. Each of the `bindings` must contain at least one member.
-  repeated Binding bindings = 134816398;
+  repeated Binding bindings = 403251854;
 
   // `etag` is used for optimistic concurrency control as a way to help prevent simultaneous updates of a policy from overwriting each other. It is strongly suggested that systems make use of the `etag` in the read-modify-write cycle to perform policy updates in order to avoid race conditions: An `etag` is returned in the response to `getIamPolicy`, and systems are expected to put that etag in the request to `setIamPolicy` to ensure that their change will be applied to the same version of the policy.
   //
   // **Important:** If you use IAM Conditions, you must include the `etag` field whenever you call `setIamPolicy`. If you omit this field, then IAM allows you to overwrite a version `3` policy with a version `1` policy, and all of the conditions in the version `3` policy are lost.
   optional string etag = 3123477;
 
-  optional bool iam_owned = 182130747;
+  optional bool iam_owned = 450566203;
 
   // If more than one rule is specified, the rules are applied in the following manner: - All matching LOG rules are always applied. - If any DENY/DENY_WITH_LOG rule matches, permission is denied. Logging will be applied if one or more matching rule requires logging. - Otherwise, if any ALLOW/ALLOW_WITH_LOG rule matches, permission is granted. Logging will be applied if one or more matching rule requires logging. - Otherwise, if no rule applies, permission is denied.
   repeated Rule rules = 108873975;
@@ -3740,14 +3740,14 @@ message Policy {
   // If a policy does not include any conditions, operations on that policy may specify any valid version or leave the field unset.
   //
   // To learn which resources support conditions in their IAM policies, see the [IAM documentation](https://cloud.google.com/iam/help/conditions/resource-policies).
-  optional int32 version = 83172568;
+  optional int32 version = 351608024;
 
 }
 
 //
 message GlobalSetPolicyRequest {
   // Flatten Policy to create a backward compatible wire-format. Deprecated. Use 'policy' to specify bindings.
-  repeated Binding bindings = 134816398;
+  repeated Binding bindings = 403251854;
 
   // Flatten Policy to create a backward compatible wire-format. Deprecated. Use 'policy' to specify the etag.
   optional string etag = 3123477;
@@ -3769,13 +3769,13 @@ message GuestAttributes {
   optional string kind = 3292052;
 
   // The path to be queried. This can be the default namespace ('/') or a nested namespace ('/\/') or a specified key ('/\/\')
-  optional string query_path = 100155708;
+  optional string query_path = 368591164;
 
   // [Output Only] The value of the requested queried path.
   optional GuestAttributesValue query_value = 157570874;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // The key to search for.
   optional string variable_key = 164364828;
@@ -3813,9 +3813,9 @@ message HTTP2HealthCheck {
 
     USE_FIXED_PORT = 190235748;
 
-    USE_NAMED_PORT = 80865215;
+    USE_NAMED_PORT = 349300671;
 
-    USE_SERVING_PORT = 94202060;
+    USE_SERVING_PORT = 362637516;
 
   }
 
@@ -3826,7 +3826,7 @@ message HTTP2HealthCheck {
 
     NONE = 2402104;
 
-    PROXY_V1 = 65917484;
+    PROXY_V1 = 334352940;
 
   }
 
@@ -3874,9 +3874,9 @@ message HTTPHealthCheck {
 
     USE_FIXED_PORT = 190235748;
 
-    USE_NAMED_PORT = 80865215;
+    USE_NAMED_PORT = 349300671;
 
-    USE_SERVING_PORT = 94202060;
+    USE_SERVING_PORT = 362637516;
 
   }
 
@@ -3887,7 +3887,7 @@ message HTTPHealthCheck {
 
     NONE = 2402104;
 
-    PROXY_V1 = 65917484;
+    PROXY_V1 = 334352940;
 
   }
 
@@ -3935,9 +3935,9 @@ message HTTPSHealthCheck {
 
     USE_FIXED_PORT = 190235748;
 
-    USE_NAMED_PORT = 80865215;
+    USE_NAMED_PORT = 349300671;
 
-    USE_SERVING_PORT = 94202060;
+    USE_SERVING_PORT = 362637516;
 
   }
 
@@ -3948,7 +3948,7 @@ message HTTPSHealthCheck {
 
     NONE = 2402104;
 
-    PROXY_V1 = 65917484;
+    PROXY_V1 = 334352940;
 
   }
 
@@ -3984,7 +3984,7 @@ message HTTPSHealthCheck {
 // Configuration of logging on a health check. If logging is enabled, logs will be exported to Stackdriver.
 message HealthCheckLogConfig {
   // Indicates whether or not to export logs. This is false by default, which means no health check logging will be done.
-  optional bool enable = 43328899;
+  optional bool enable = 311764355;
 
 }
 
@@ -4003,9 +4003,9 @@ message SSLHealthCheck {
 
     USE_FIXED_PORT = 190235748;
 
-    USE_NAMED_PORT = 80865215;
+    USE_NAMED_PORT = 349300671;
 
-    USE_SERVING_PORT = 94202060;
+    USE_SERVING_PORT = 362637516;
 
   }
 
@@ -4016,7 +4016,7 @@ message SSLHealthCheck {
 
     NONE = 2402104;
 
-    PROXY_V1 = 65917484;
+    PROXY_V1 = 334352940;
 
   }
 
@@ -4061,9 +4061,9 @@ message TCPHealthCheck {
 
     USE_FIXED_PORT = 190235748;
 
-    USE_NAMED_PORT = 80865215;
+    USE_NAMED_PORT = 349300671;
 
-    USE_SERVING_PORT = 94202060;
+    USE_SERVING_PORT = 362637516;
 
   }
 
@@ -4074,7 +4074,7 @@ message TCPHealthCheck {
 
     NONE = 2402104;
 
-    PROXY_V1 = 65917484;
+    PROXY_V1 = 334352940;
 
   }
 
@@ -4135,7 +4135,7 @@ message HealthCheck {
 
     HTTPS = 69079243;
 
-    INVALID = 261848535;
+    INVALID = 530283991;
 
     SSL = 82412;
 
@@ -4144,24 +4144,24 @@ message HealthCheck {
   }
 
   // How often (in seconds) to send a health check. The default value is 5 seconds.
-  optional int32 check_interval_sec = 77125550;
+  optional int32 check_interval_sec = 345561006;
 
   // [Output Only] Creation timestamp in 3339 text format.
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   optional GRPCHealthCheck grpc_health_check = 85529574;
 
   // A so-far unhealthy instance will be marked healthy after this many consecutive successes. The default value is 2.
-  optional int32 healthy_threshold = 134776905;
+  optional int32 healthy_threshold = 403212361;
 
   optional HTTP2HealthCheck http2_health_check = 11360986;
 
-  optional HTTPHealthCheck http_health_check = 144151484;
+  optional HTTPHealthCheck http_health_check = 412586940;
 
-  optional HTTPSHealthCheck https_health_check = 167611449;
+  optional HTTPSHealthCheck https_health_check = 436046905;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -4170,7 +4170,7 @@ message HealthCheck {
   optional string kind = 3292052;
 
   // Configure logging on this health check.
-  optional HealthCheckLogConfig log_config = 82864285;
+  optional HealthCheckLogConfig log_config = 351299741;
 
   // Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
   optional string name = 3373707;
@@ -4179,11 +4179,11 @@ message HealthCheck {
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
-  optional SSLHealthCheck ssl_health_check = 11596984;
+  optional SSLHealthCheck ssl_health_check = 280032440;
 
-  optional TCPHealthCheck tcp_health_check = 201544963;
+  optional TCPHealthCheck tcp_health_check = 469980419;
 
   // How long (in seconds) to wait before claiming failure. The default value is 5 seconds. It is invalid for timeoutSec to have greater value than checkIntervalSec.
   optional int32 timeout_sec = 79994995;
@@ -4211,7 +4211,7 @@ message HealthCheckList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -4223,7 +4223,7 @@ message HealthCheckList {
 // - projects/project-id/global/httpHealthChecks/health-check
 // - global/httpHealthChecks/health-check
 message HealthCheckReference {
-  optional string health_check = 40441189;
+  optional string health_check = 308876645;
 
 }
 
@@ -4240,7 +4240,7 @@ message HealthCheckService {
 
     AND = 64951;
 
-    NO_AGGREGATION = 158009668;
+    NO_AGGREGATION = 426445124;
 
   }
 
@@ -4248,13 +4248,13 @@ message HealthCheckService {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Fingerprint of this resource. A hash of the contents stored in this object. This field is used in optimistic locking. This field will be ignored when inserting a HealthCheckService. An up-to-date fingerprint must be provided in order to patch/update the HealthCheckService; Otherwise, the request will fail with error 412 conditionNotMet. To see the latest fingerprint, make a get() request to retrieve the HealthCheckService.
   optional string fingerprint = 234678500;
 
   // List of URLs to the HealthCheck resources. Must have at least one HealthCheck, and not more than 10. HealthCheck resources must have portSpecification=USE_SERVING_PORT. For regional HealthCheckService, the HealthCheck must be regional and in the same region. For global HealthCheckService, HealthCheck must be global. Mix of regional and global HealthChecks is not supported. Multiple regional HealthChecks must belong to the same region. Regional HealthChecks</code? must belong to the same region as zones of NEGs.
-  repeated string health_checks = 179935150;
+  repeated string health_checks = 448370606;
 
   // Optional. Policy for how the results from multiple health checks for the same endpoint are aggregated. Defaults to NO_AGGREGATION if unspecified.
   // - NO_AGGREGATION. An EndpointHealth message is returned for each backend in the health check service.
@@ -4274,13 +4274,13 @@ message HealthCheckService {
   repeated string network_endpoint_groups = 29346733;
 
   // List of URLs to the NotificationEndpoint resources. Must not have more than 10. A list of endpoints for receiving notifications of change in health status. For regional HealthCheckService, NotificationEndpoint must be regional and in the same region. For global HealthCheckService, NotificationEndpoint must be global.
-  repeated string notification_endpoints = 138293034;
+  repeated string notification_endpoints = 406728490;
 
   // [Output Only] URL of the region where the health check service resides. This field is not applicable to global health check services. You must specify this field as part of the HTTP request URL. It is not settable as a field in the request body.
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
 }
 
@@ -4289,7 +4289,7 @@ message HealthCheckService {
 // - projects/project-id/regions/us-west1/healthCheckServices/health-check-service
 // - regions/us-west1/healthCheckServices/health-check-service
 message HealthCheckServiceReference {
-  optional string health_check_service = 139939291;
+  optional string health_check_service = 408374747;
 
 }
 
@@ -4308,7 +4308,7 @@ message HealthCheckServicesList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -4318,7 +4318,7 @@ message HealthCheckServicesList {
 //
 message HealthChecksScopedList {
   // A list of HealthChecks contained in this scope.
-  repeated HealthCheck health_checks = 179935150;
+  repeated HealthCheck health_checks = 448370606;
 
   // Informational warning which replaces the list of backend services when the list is empty.
   optional Warning warning = 50704284;
@@ -4340,7 +4340,7 @@ message HealthChecksAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -4357,44 +4357,44 @@ message HealthStatusForNetworkEndpoint {
     // A value indicating that the enum field is not set.
     UNDEFINED_HEALTH_STATE = 0;
 
-    DRAINING = 212019946;
+    DRAINING = 480455402;
 
-    HEALTHY = 171365757;
+    HEALTHY = 439801213;
 
-    UNHEALTHY = 193682628;
+    UNHEALTHY = 462118084;
 
-    UNKNOWN = 164706346;
+    UNKNOWN = 433141802;
 
   }
 
   // URL of the backend service associated with the health state of the network endpoint.
-  optional BackendServiceReference backend_service = 38510602;
+  optional BackendServiceReference backend_service = 306946058;
 
   // URL of the forwarding rule associated with the health state of the network endpoint.
-  optional ForwardingRuleReference forwarding_rule = 1528574;
+  optional ForwardingRuleReference forwarding_rule = 269964030;
 
   // URL of the health check associated with the health state of the network endpoint.
-  optional HealthCheckReference health_check = 40441189;
+  optional HealthCheckReference health_check = 308876645;
 
   // URL of the health check service associated with the health state of the network endpoint.
-  optional HealthCheckServiceReference health_check_service = 139939291;
+  optional HealthCheckServiceReference health_check_service = 408374747;
 
   // Health state of the network endpoint determined based on the health checks configured.
-  optional HealthState health_state = 55571694;
+  optional HealthState health_state = 324007150;
 
 }
 
 // UrlMaps A host-matching rule for a URL. If matched, will use the named PathMatcher to select the BackendService.
 message HostRule {
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // The list of host patterns to match. They must be valid hostnames with optional port numbers in the format host:port. * matches any string of ([a-z0-9-.]*). In that case, * must be the first character and must be followed in the pattern by either - or ..
   // * based matching is not supported when the URL map is bound to target gRPC proxy that has validateForProxyless field set to true.
   repeated string hosts = 99467211;
 
   // The name of the PathMatcher to use to match the path portion of the URL if the hostRule matches the URL's host portion.
-  optional string path_matcher = 69377816;
+  optional string path_matcher = 337813272;
 
 }
 
@@ -4402,7 +4402,7 @@ message HostRule {
 message HttpFaultAbort {
   // The HTTP status code used to abort the request.
   // The value must be between 200 and 599 inclusive.
-  optional uint32 http_status = 200514441;
+  optional uint32 http_status = 468949897;
 
   // The percentage of traffic (connections/operations/requests) which will be aborted as part of fault injection.
   // The value must be between 0.0 and 100.0 inclusive.
@@ -4413,7 +4413,7 @@ message HttpFaultAbort {
 // Specifies the delay introduced by Loadbalancer before forwarding the request to the backend service as part of fault injection.
 message HttpFaultDelay {
   // Specifies the value of the fixed delay interval.
-  optional Duration fixed_delay = 48602360;
+  optional Duration fixed_delay = 317037816;
 
   // The percentage of traffic (connections/operations/requests) on which delay will be introduced as part of fault injection.
   // The value must be between 0.0 and 100.0 inclusive.
@@ -4464,7 +4464,7 @@ message HttpHeaderAction {
 // HttpRouteRuleMatch criteria for field values that must stay within the specified integer range.
 message Int64RangeMatch {
   // The end of the range (exclusive) in signed long integer format.
-  optional string range_end = 54004441;
+  optional string range_end = 322439897;
 
   // The start of the range (inclusive) in signed long integer format.
   optional string range_start = 103333600;
@@ -4475,7 +4475,7 @@ message Int64RangeMatch {
 message HttpHeaderMatch {
   // The value should exactly match contents of exactMatch.
   // Only one of exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch must be set.
-  optional string exact_match = 189205637;
+  optional string exact_match = 457641093;
 
   // The name of the HTTP header to match.
   // For matching against the HTTP request's authority, use a headerMatch with the header name ":authority".
@@ -4485,7 +4485,7 @@ message HttpHeaderMatch {
 
   // If set to false, the headerMatch is considered a match if the match criteria above are met. If set to true, the headerMatch is considered a match if the match criteria above are NOT met.
   // The default setting is false.
-  optional bool invert_match = 232694812;
+  optional bool invert_match = 501130268;
 
   // The value of the header must start with the contents of prefixMatch.
   // Only one of exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch must be set.
@@ -4513,7 +4513,7 @@ message HttpHeaderMatch {
 
   // The value of the header must end with the contents of suffixMatch.
   // Only one of exactMatch, prefixMatch, suffixMatch, regexMatch, presentMatch or rangeMatch must be set.
-  optional string suffix_match = 158053207;
+  optional string suffix_match = 426488663;
 
 }
 
@@ -4521,7 +4521,7 @@ message HttpHeaderMatch {
 message HttpQueryParameterMatch {
   // The queryParameterMatch matches if the value of the parameter exactly matches the contents of exactMatch.
   // Only one of presentMatch, exactMatch or regexMatch must be set.
-  optional string exact_match = 189205637;
+  optional string exact_match = 457641093;
 
   // The name of the query parameter to match. The query parameter must exist in the request, in the absence of which the request match fails.
   optional string name = 3373707;
@@ -4552,13 +4552,13 @@ message HttpRedirectAction {
 
     FOUND = 67084130;
 
-    MOVED_PERMANENTLY_DEFAULT = 118262993;
+    MOVED_PERMANENTLY_DEFAULT = 386698449;
 
-    PERMANENT_REDIRECT = 113570925;
+    PERMANENT_REDIRECT = 382006381;
 
-    SEE_OTHER = 176945124;
+    SEE_OTHER = 445380580;
 
-    TEMPORARY_REDIRECT = 221114922;
+    TEMPORARY_REDIRECT = 489550378;
 
   }
 
@@ -4574,12 +4574,12 @@ message HttpRedirectAction {
   // The path that will be used in the redirect response instead of the one that was supplied in the request.
   // pathRedirect cannot be supplied together with prefixRedirect. Supply one alone or neither. If neither is supplied, the path of the original request will be used for the redirect.
   // The value must be between 1 and 1024 characters.
-  optional string path_redirect = 3907254;
+  optional string path_redirect = 272342710;
 
   // The prefix that replaces the prefixMatch specified in the HttpRouteRuleMatch, retaining the remaining portion of the URL before redirecting the request.
   // prefixRedirect cannot be supplied together with pathRedirect. Supply one alone or neither. If neither is supplied, the path of the original request will be used for the redirect.
   // The value must be between 1 and 1024 characters.
-  optional string prefix_redirect = 177748713;
+  optional string prefix_redirect = 446184169;
 
   // The HTTP Status code to use for this RedirectAction.
   // Supported values are:
@@ -4588,7 +4588,7 @@ message HttpRedirectAction {
   // - SEE_OTHER which corresponds to 303.
   // - TEMPORARY_REDIRECT, which corresponds to 307. In this case, the request method will be retained.
   // - PERMANENT_REDIRECT, which corresponds to 308. In this case, the request method will be retained.
-  optional RedirectResponseCode redirect_response_code = 168274952;
+  optional RedirectResponseCode redirect_response_code = 436710408;
 
   // If set to true, any accompanying query portion of the original URL is removed prior to redirecting the request. If set to false, the query portion of the original URL is retained.
   // The default is set to false.
@@ -4603,7 +4603,7 @@ message HttpRetryPolicy {
 
   // Specifies a non-zero timeout per retry attempt.
   // If not specified, will use the timeout set in HttpRouteAction. If timeout in HttpRouteAction is not set, will use the largest timeout among all backend services associated with the route.
-  optional Duration per_try_timeout = 11605691;
+  optional Duration per_try_timeout = 280041147;
 
   // Specfies one or more conditions when this retry rule applies. Valid values are:
   // - 5xx: Loadbalancer will attempt a retry if the backend service responds with any 5xx response code, or if the backend service does not respond at all, example: disconnects, reset, read timeout, connection failure, and refused streams.
@@ -4623,7 +4623,7 @@ message HttpRetryPolicy {
 // A policy that specifies how requests intended for the route's backends are shadowed to a separate mirrored backend service. Loadbalancer does not wait for responses from the shadow service. Prior to sending traffic to the shadow service, the host / authority header is suffixed with -shadow.
 message RequestMirrorPolicy {
   // The full or partial URL to the BackendService resource being mirrored to.
-  optional string backend_service = 38510602;
+  optional string backend_service = 306946058;
 
 }
 
@@ -4642,18 +4642,18 @@ message UrlRewrite {
 // In contrast to a single BackendService in  HttpRouteAction to which all matching traffic is directed to, WeightedBackendService allows traffic to be split across multiple BackendServices. The volume of traffic for each BackendService is proportional to the weight specified in each WeightedBackendService
 message WeightedBackendService {
   // The full or partial URL to the default BackendService resource. Before forwarding the request to backendService, the loadbalancer applies any relevant headerActions specified as part of this backendServiceWeight.
-  optional string backend_service = 38510602;
+  optional string backend_service = 306946058;
 
   // Specifies changes to request and response headers that need to take effect for the selected backendService.
   // headerAction specified here take effect before headerAction in the enclosing HttpRouteRule, PathMatcher and UrlMap.
   // Note that headerAction is not supported for Loadbalancers that have their loadBalancingScheme set to EXTERNAL.
   // Not supported when the URL map is bound to target gRPC proxy that has validateForProxyless field set to true.
-  optional HttpHeaderAction header_action = 59641896;
+  optional HttpHeaderAction header_action = 328077352;
 
   // Specifies the fraction of traffic sent to backendService, computed as weight / (sum of all weightedBackendService weights in routeAction) .
   // The selection of a backend service is determined only for new traffic. Once a user's request has been directed to a backendService, subsequent requests will be sent to the same backendService as determined by the BackendService's session affinity policy.
   // The value must be between 0 and 1000
-  optional uint32 weight = 13714040;
+  optional uint32 weight = 282149496;
 
 }
 
@@ -4661,12 +4661,12 @@ message WeightedBackendService {
 message HttpRouteAction {
   // The specification for allowing client side cross-origin requests. Please see W3C Recommendation for Cross Origin Resource Sharing
   // Not supported when the URL map is bound to target gRPC proxy.
-  optional CorsPolicy cors_policy = 130508292;
+  optional CorsPolicy cors_policy = 398943748;
 
   // The specification for fault injection introduced into traffic to test the resiliency of clients to backend service failure. As part of fault injection, when clients send requests to a backend service, delays can be introduced by Loadbalancer on a percentage of requests before sending those request to the backend service. Similarly requests from clients can be aborted by the Loadbalancer for a percentage of requests.
   // timeout and retry_policy will be ignored by clients that are configured with a fault_injection_policy.
   // Not supported when the URL map is bound to target gRPC proxy that has validateForProxyless field set to true.
-  optional HttpFaultInjection fault_injection_policy = 144345623;
+  optional HttpFaultInjection fault_injection_policy = 412781079;
 
   // Specifies the policy on how requests intended for the route's backends are shadowed to a separate mirrored backend service. Loadbalancer does not wait for responses from the shadow service. Prior to sending traffic to the shadow service, the host / authority header is suffixed with -shadow.
   // Not supported when the URL map is bound to target gRPC proxy that has validateForProxyless field set to true.
@@ -4679,16 +4679,16 @@ message HttpRouteAction {
   // Specifies the timeout for the selected route. Timeout is computed from the time the request has been fully processed (i.e. end-of-stream) up until the response has been completely processed. Timeout includes all retries.
   // If not specified, will use the largest timeout among all backend services associated with the route.
   // Not supported when the URL map is bound to target gRPC proxy that has validateForProxyless field set to true.
-  optional Duration timeout = 28265825;
+  optional Duration timeout = 296701281;
 
   // The spec to modify the URL of the request, prior to forwarding the request to the matched service.
   // urlRewrite is the only action supported in UrlMaps for external HTTP(S) load balancers.
   // Not supported when the URL map is bound to target gRPC proxy that has validateForProxyless field set to true.
-  optional UrlRewrite url_rewrite = 4898492;
+  optional UrlRewrite url_rewrite = 273333948;
 
   // A list of weighted backend services to send traffic to when a route match occurs. The weights determine the fraction of traffic that flows to their corresponding backend service. If all traffic needs to go to a single backend service, there must be one  weightedBackendService with weight set to a non-zero number.
   // Once a backendService is identified and before forwarding the request to the backend service, advanced routing actions such as URL rewrites and header transformations are applied depending on additional settings specified in this HttpRouteAction.
-  repeated WeightedBackendService weighted_backend_services = 68592593;
+  repeated WeightedBackendService weighted_backend_services = 337028049;
 
 }
 
@@ -4700,20 +4700,20 @@ message HttpRouteRuleMatch {
   optional string full_path_match = 214598875;
 
   // Specifies a list of header match criteria, all of which must match corresponding headers in the request.
-  repeated HttpHeaderMatch header_matches = 93468033;
+  repeated HttpHeaderMatch header_matches = 361903489;
 
   // Specifies that prefixMatch and fullPathMatch matches are case sensitive.
   // The default value is false.
   // ignoreCase must not be used with regexMatch.
   // Not supported when the URL map is bound to target gRPC proxy.
-  optional bool ignore_case = 195889533;
+  optional bool ignore_case = 464324989;
 
   // Opaque filter criteria used by Loadbalancer to restrict routing configuration to a limited set of xDS compliant clients. In their xDS requests to Loadbalancer, xDS clients present node metadata. When there is a match, the relevant routing configuration is made available to those proxies.
   // For each metadataFilter in this list, if its filterMatchCriteria is set to MATCH_ANY, at least one of the filterLabels must match the corresponding label provided in the metadata. If its filterMatchCriteria is set to MATCH_ALL, then all of its filterLabels must match with corresponding labels provided in the metadata. If multiple metadataFilters are specified, all of them need to be satisfied in order to be considered a match.
   // metadataFilters specified here will be applied after those specified in ForwardingRule that refers to the UrlMap this HttpRouteRuleMatch belongs to.
   // metadataFilters only applies to Loadbalancers that have their loadBalancingScheme set to INTERNAL_SELF_MANAGED.
   // Not supported when the URL map is bound to target gRPC proxy that has validateForProxyless field set to true.
-  repeated MetadataFilter metadata_filters = 196290283;
+  repeated MetadataFilter metadata_filters = 464725739;
 
   // For satisfying the matchRule condition, the request's path must begin with the specified prefixMatch. prefixMatch must begin with a /.
   // The value must be between 1 and 1024 characters.
@@ -4722,7 +4722,7 @@ message HttpRouteRuleMatch {
 
   // Specifies a list of query parameter match criteria, all of which must match corresponding query parameters in the request.
   // Not supported when the URL map is bound to target gRPC proxy.
-  repeated HttpQueryParameterMatch query_parameter_matches = 17795814;
+  repeated HttpQueryParameterMatch query_parameter_matches = 286231270;
 
   // For satisfying the matchRule condition, the path of the request must satisfy the regular expression specified in regexMatch after removing any query parameters and anchor supplied with the original URL. For regular expression grammar please see en.cppreference.com/w/cpp/regex/ecmascript
   // Only one of prefixMatch, fullPathMatch or regexMatch must be specified.
@@ -4735,35 +4735,35 @@ message HttpRouteRuleMatch {
 message HttpRouteRule {
   // The short description conveying the intent of this routeRule.
   // The description can have a maximum length of 1024 characters.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Specifies changes to request and response headers that need to take effect for the selected backendService.
   // The headerAction specified here are applied before the matching pathMatchers[].headerAction and after pathMatchers[].routeRules[].routeAction.weightedBackendService.backendServiceWeightAction[].headerAction
   // Note that headerAction is not supported for Loadbalancers that have their loadBalancingScheme set to EXTERNAL.
   // Not supported when the URL map is bound to target gRPC proxy that has validateForProxyless field set to true.
-  optional HttpHeaderAction header_action = 59641896;
+  optional HttpHeaderAction header_action = 328077352;
 
   // The list of criteria for matching attributes of a request to this routeRule. This list has OR semantics: the request matches this routeRule when any of the matchRules are satisfied. However predicates within a given matchRule have AND semantics. All predicates within a matchRule must match for the request to match the rule.
-  repeated HttpRouteRuleMatch match_rules = 107765245;
+  repeated HttpRouteRuleMatch match_rules = 376200701;
 
   // For routeRules within a given pathMatcher, priority determines the order in which load balancer will interpret routeRules. RouteRules are evaluated in order of priority, from the lowest to highest number. The priority of a rule decreases as its number increases (1, 2, 3, N+1). The first rule that matches the request is applied.
   // You cannot configure two or more routeRules with the same priority. Priority for each rule must be set to a number between 0 and 2147483647 inclusive.
   // Priority numbers can have gaps, which enable you to add or remove rules in the future without affecting the rest of the rules. For example, 1, 2, 3, 4, 5, 9, 12, 16 is a valid series of priority numbers to which you could add rules numbered from 6 to 8, 10 to 11, and 13 to 15 in the future without any impact on existing rules.
-  optional int32 priority = 176716196;
+  optional int32 priority = 445151652;
 
   // In response to a matching matchRule, the load balancer performs advanced routing actions like URL rewrites, header transformations, etc. prior to forwarding the request to the selected backend. If  routeAction specifies any  weightedBackendServices, service must not be set. Conversely if service is set, routeAction cannot contain any  weightedBackendServices.
   // Only one of urlRedirect, service or routeAction.weightedBackendService must be set.
   // UrlMaps for external HTTP(S) load balancers support only the urlRewrite action within a routeRule's routeAction.
-  optional HttpRouteAction route_action = 156128492;
+  optional HttpRouteAction route_action = 424563948;
 
   // The full or partial URL of the backend service resource to which traffic is directed if this rule is matched. If routeAction is additionally specified, advanced routing actions like URL Rewrites, etc. take effect prior to sending the request to the backend. However, if service is specified, routeAction cannot contain any weightedBackendService s. Conversely, if routeAction specifies any  weightedBackendServices, service must not be specified.
   // Only one of urlRedirect, service or routeAction.weightedBackendService must be set.
-  optional string service = 105105077;
+  optional string service = 373540533;
 
   // When this rule is matched, the request is redirected to a URL specified by urlRedirect.
   // If urlRedirect is specified, service or routeAction must not be set.
   // Not supported when the URL map is bound to target gRPC proxy.
-  optional HttpRedirectAction url_redirect = 136712364;
+  optional HttpRedirectAction url_redirect = 405147820;
 
 }
 
@@ -4779,10 +4779,10 @@ message RawDisk {
   }
 
   // The format used to encode and transmit the block device, which should be TAR. This is just a container and transmission format and not a runtime format. Provided by the client when the disk image is created.
-  optional ContainerType container_type = 50373688;
+  optional ContainerType container_type = 318809144;
 
   // [Deprecated] This field is deprecated. An optional SHA1 checksum of the disk image before unpackaging provided by the client when the disk image is created.
-  optional string sha1_checksum = 46008893;
+  optional string sha1_checksum = 314444349;
 
   // The full Google Cloud Storage URL where the disk image is stored. You must provide either this property or the sourceDisk property but not both.
   optional string source = 177235995;
@@ -4807,9 +4807,9 @@ message Image {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    DELETING = 260166568;
+    DELETING = 528602024;
 
-    FAILED = 187271229;
+    FAILED = 455706685;
 
     PENDING = 35394935;
 
@@ -4818,22 +4818,22 @@ message Image {
   }
 
   // Size of the image tar.gz archive stored in Google Cloud Storage (in bytes).
-  optional string archive_size_bytes = 112657994;
+  optional string archive_size_bytes = 381093450;
 
   // [Output Only] Creation timestamp in RFC3339 text format.
   optional string creation_timestamp = 30525366;
 
   // The deprecation status associated with this image.
-  optional DeprecationStatus deprecated = 246703539;
+  optional DeprecationStatus deprecated = 515138995;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Size of the image when restored onto a persistent disk (in GB).
-  optional string disk_size_gb = 47828279;
+  optional string disk_size_gb = 316263735;
 
   // The name of the image family to which this image belongs. You can create disks by specifying an image family instead of a specific image name. The image family always returns its latest image that is not deprecated. The name of the image family must comply with RFC1035.
-  optional string family = 60316516;
+  optional string family = 328751972;
 
   // A list of features to enable on the guest operating system. Applicable only for bootable images. Read  Enabling guest operating system features to see a list of available options.
   repeated GuestOsFeature guest_os_features = 79294545;
@@ -4848,7 +4848,7 @@ message Image {
   // Customer-supplied encryption keys do not protect access to metadata of the disk.
   //
   // If you do not provide an encryption key when creating the image, then the disk will be encrypted using an automatically generated key and you do not need to provide a key to use the image later.
-  optional CustomerEncryptionKey image_encryption_key = 111077127;
+  optional CustomerEncryptionKey image_encryption_key = 379512583;
 
   // [Output Only] Type of the resource. Always compute#image for images.
   optional string kind = 3292052;
@@ -4859,22 +4859,22 @@ message Image {
   optional string label_fingerprint = 178124825;
 
   // Labels to apply to this image. These can be later modified by the setLabels method.
-  map<string, string> labels = 231759871;
+  map<string, string> labels = 500195327;
 
   // Integer license codes indicating which licenses are attached to this image.
   repeated string license_codes = 45482664;
 
   // Any applicable license URI.
-  repeated string licenses = 69207122;
+  repeated string licenses = 337642578;
 
   // Name of the resource; provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
   optional string name = 3373707;
 
   // The parameters of the raw disk image.
-  optional RawDisk raw_disk = 234678100;
+  optional RawDisk raw_disk = 503113556;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // Set the secure boot keys of shielded instance.
   optional InitialStateConfig shielded_instance_initial_state = 192356867;
@@ -4883,13 +4883,13 @@ message Image {
   // - https://www.googleapis.com/compute/v1/projects/project/zones/zone/disks/disk
   // - projects/project/zones/zone/disks/disk
   // - zones/zone/disks/disk
-  optional string source_disk = 183318337;
+  optional string source_disk = 451753793;
 
   // The customer-supplied encryption key of the source disk. Required if the source disk is protected by a customer-supplied encryption key.
-  optional CustomerEncryptionKey source_disk_encryption_key = 263065697;
+  optional CustomerEncryptionKey source_disk_encryption_key = 531501153;
 
   // [Output Only] The ID value of the disk used to create this image. This value may be used to determine whether the image was taken from the current or a previous instance of a given disk name.
-  optional string source_disk_id = 185755353;
+  optional string source_disk_id = 454190809;
 
   // URL of the source image used to create this image.
   //
@@ -4901,7 +4901,7 @@ message Image {
   optional string source_image = 50443319;
 
   // The customer-supplied encryption key of the source image. Required if the source image is protected by a customer-supplied encryption key.
-  optional CustomerEncryptionKey source_image_encryption_key = 113068203;
+  optional CustomerEncryptionKey source_image_encryption_key = 381503659;
 
   // [Output Only] The ID value of the image used to create this image. This value may be used to determine whether the image was taken from the current or a previous instance of a given image name.
   optional string source_image_id = 55328291;
@@ -4917,19 +4917,19 @@ message Image {
   optional string source_snapshot = 126061928;
 
   // The customer-supplied encryption key of the source snapshot. Required if the source snapshot is protected by a customer-supplied encryption key.
-  optional CustomerEncryptionKey source_snapshot_encryption_key = 35243866;
+  optional CustomerEncryptionKey source_snapshot_encryption_key = 303679322;
 
   // [Output Only] The ID value of the snapshot used to create this image. This value may be used to determine whether the snapshot was taken from the current or a previous instance of a given snapshot name.
   optional string source_snapshot_id = 98962258;
 
   // The type of the image used to create this disk. The default and only value is RAW
-  optional SourceType source_type = 183810270;
+  optional SourceType source_type = 452245726;
 
   // [Output Only] The status of the image. An image can be used to create other resources, such as instances, only after the image has been successfully created and the status is set to READY. Possible values are FAILED, PENDING, or READY.
   optional Status status = 181260274;
 
   // Cloud Storage bucket storage location of the image (regional or multi-regional).
-  repeated string storage_locations = 59569818;
+  repeated string storage_locations = 328005274;
 
 }
 
@@ -4948,7 +4948,7 @@ message ImageList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -4981,7 +4981,7 @@ message NetworkInterface {
 
     UNSPECIFIED_NIC_TYPE = 67411801;
 
-    VIRTIO_NET = 183688025;
+    VIRTIO_NET = 452123481;
 
   }
 
@@ -4995,7 +4995,7 @@ message NetworkInterface {
   optional string fingerprint = 234678500;
 
   // [Output Only] An IPv6 internal network address for this network interface.
-  optional string ipv6_address = 73128348;
+  optional string ipv6_address = 341563804;
 
   // [Output Only] Type of the resource. Always compute#networkInterface for network interfaces.
   optional string kind = 3292052;
@@ -5020,7 +5020,7 @@ message NetworkInterface {
   // The URL of the Subnetwork resource for this instance. If the network resource is in legacy mode, do not specify this field. If the network is in auto subnet mode, specifying the subnetwork is optional. If the network is in custom subnet mode, specifying the subnetwork is required. If you specify this field, you can specify the subnetwork as a full or partial URL. For example, the following are all valid URLs:
   // - https://www.googleapis.com/compute/v1/projects/project/regions/region/subnetworks/subnetwork
   // - regions/region/subnetworks/subnetwork
-  optional string subnetwork = 39392238;
+  optional string subnetwork = 307827694;
 
 }
 
@@ -5037,12 +5037,12 @@ message ReservationAffinity {
 
     SPECIFIC_RESERVATION = 229889055;
 
-    UNSPECIFIED = 258350871;
+    UNSPECIFIED = 526786327;
 
   }
 
   // Specifies the type of reservation from which this instance can consume resources: ANY_RESERVATION (default), SPECIFIC_RESERVATION, or NO_RESERVATION. See  Consuming reserved instances for examples.
-  optional ConsumeReservationType consume_reservation_type = 32301488;
+  optional ConsumeReservationType consume_reservation_type = 300736944;
 
   // Corresponds to the label key of a reservation resource. To target a SPECIFIC_RESERVATION by name, specify googleapis.com/reservation-name as the key and specify the name of your reservation as its value.
   optional string key = 106079;
@@ -5061,29 +5061,29 @@ message Scheduling {
 
     MIGRATE = 165699979;
 
-    TERMINATE = 259182145;
+    TERMINATE = 527617601;
 
   }
 
   // Specifies whether the instance should be automatically restarted if it is terminated by Compute Engine (not terminated by a user). You can only set the automatic restart option for standard instances. Preemptible instances cannot be automatically restarted.
   //
   // By default, this is set to true so an instance is automatically restarted if it is terminated by Compute Engine.
-  optional bool automatic_restart = 82385915;
+  optional bool automatic_restart = 350821371;
 
   // An opaque location hint used to place the instance close to other resources. This field is for use by internal tools that use the public API.
-  optional string location_hint = 82084049;
+  optional string location_hint = 350519505;
 
   // The minimum number of virtual CPUs this instance will consume when running on a sole-tenant node.
-  optional int32 min_node_cpus = 48796219;
+  optional int32 min_node_cpus = 317231675;
 
   // A set of node affinity and anti-affinity configurations. Refer to Configuring node affinity for more information. Overrides reservationAffinity.
-  repeated SchedulingNodeAffinity node_affinities = 193364515;
+  repeated SchedulingNodeAffinity node_affinities = 461799971;
 
   // Defines the maintenance behavior for this instance. For standard instances, the default behavior is MIGRATE. For preemptible instances, the default and only possible behavior is TERMINATE. For more information, see Setting Instance Scheduling Options.
   optional OnHostMaintenance on_host_maintenance = 64616796;
 
   // Defines whether the instance is preemptible. This can only be set during instance creation or while the instance is stopped and therefore, in a `TERMINATED` state. See Instance Life Cycle for more information on the possible instance states.
-  optional bool preemptible = 55767713;
+  optional bool preemptible = 324203169;
 
 }
 
@@ -5100,7 +5100,7 @@ message ServiceAccount {
 // A set of Shielded Instance options.
 message ShieldedInstanceConfig {
   // Defines whether the instance has integrity monitoring enabled. Enabled by default.
-  optional bool enable_integrity_monitoring = 140635574;
+  optional bool enable_integrity_monitoring = 409071030;
 
   // Defines whether the instance has Secure Boot enabled. Disabled by default.
   optional bool enable_secure_boot = 123568638;
@@ -5138,11 +5138,11 @@ message Instance {
     // A value indicating that the enum field is not set.
     UNDEFINED_PRIVATE_IPV6_GOOGLE_ACCESS = 0;
 
-    ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE = 159540538;
+    ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE = 427975994;
 
-    ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE = 19774807;
+    ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE = 288210263;
 
-    INHERIT_FROM_SUBNETWORK = 261821503;
+    INHERIT_FROM_SUBNETWORK = 530256959;
 
   }
 
@@ -5151,44 +5151,44 @@ message Instance {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    DEPROVISIONING = 160500206;
+    DEPROVISIONING = 428935662;
 
-    PROVISIONING = 22461165;
+    PROVISIONING = 290896621;
 
-    REPAIRING = 145047829;
+    REPAIRING = 413483285;
 
     RUNNING = 121282975;
 
-    STAGING = 162636827;
+    STAGING = 431072283;
 
-    STOPPED = 175840685;
+    STOPPED = 444276141;
 
-    STOPPING = 82356340;
+    STOPPING = 350791796;
 
     SUSPENDED = 51223995;
 
-    SUSPENDING = 245770790;
+    SUSPENDING = 514206246;
 
     TERMINATED = 250018339;
 
   }
 
   // Allows this instance to send and receive packets with non-matching destination or source IPs. This is required if you plan to use this instance to forward routes. For more information, see Enabling IP Forwarding.
-  optional bool can_ip_forward = 199295868;
+  optional bool can_ip_forward = 467731324;
 
-  optional ConfidentialInstanceConfig confidential_instance_config = 222202229;
+  optional ConfidentialInstanceConfig confidential_instance_config = 490637685;
 
   // [Output Only] The CPU platform used by this instance.
-  optional string cpu_platform = 141849898;
+  optional string cpu_platform = 410285354;
 
   // [Output Only] Creation timestamp in RFC3339 text format.
   optional string creation_timestamp = 30525366;
 
   // Whether the resource should be protected against deletion.
-  optional bool deletion_protection = 189579242;
+  optional bool deletion_protection = 458014698;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Array of disks associated with this instance. Persistent disks must be created before you can assign them.
   repeated AttachedDisk disks = 95594102;
@@ -5202,7 +5202,7 @@ message Instance {
   optional string fingerprint = 234678500;
 
   // A list of the type and count of accelerator cards attached to the instance.
-  repeated AcceleratorConfig guest_accelerators = 195159663;
+  repeated AcceleratorConfig guest_accelerators = 463595119;
 
   // Specifies the hostname of the instance. The specified hostname must be RFC1035 compliant. If hostname is not specified, the default hostname is [INSTANCE_NAME].c.[PROJECT_ID].internal when using the global DNS, and [INSTANCE_NAME].[ZONE].c.[PROJECT_ID].internal when using zonal DNS.
   optional string hostname = 237067315;
@@ -5219,16 +5219,16 @@ message Instance {
   optional string label_fingerprint = 178124825;
 
   // Labels to apply to this instance. These can be later modified by the setLabels method.
-  map<string, string> labels = 231759871;
+  map<string, string> labels = 500195327;
 
   // [Output Only] Last start timestamp in RFC3339 text format.
-  optional string last_start_timestamp = 175395280;
+  optional string last_start_timestamp = 443830736;
 
   // [Output Only] Last stop timestamp in RFC3339 text format.
-  optional string last_stop_timestamp = 144387554;
+  optional string last_stop_timestamp = 412823010;
 
   // [Output Only] Last suspended timestamp in RFC3339 text format.
-  optional string last_suspended_timestamp = 87839881;
+  optional string last_suspended_timestamp = 356275337;
 
   // Full or partial URL of the machine type resource to use for this instance, in the format: zones/zone/machineTypes/machine-type. This is provided by the client when the instance is created. For example, the following is a valid partial url to a predefined machine type:
   // zones/us-central1-f/machineTypes/n1-standard-1
@@ -5265,15 +5265,15 @@ message Instance {
   repeated string resource_policies = 22220385;
 
   // Sets the scheduling options for this instance.
-  optional Scheduling scheduling = 118252948;
+  optional Scheduling scheduling = 386688404;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // A list of service accounts, with their specified scopes, authorized for this instance. Only one service account per VM instance is supported.
   //
   // Service accounts generate access tokens that can be accessed through the metadata server and used to authenticate applications on the instance. See Service Accounts for more information.
-  repeated ServiceAccount service_accounts = 9101872;
+  repeated ServiceAccount service_accounts = 277537328;
 
   optional ShieldedInstanceConfig shielded_instance_config = 12862901;
 
@@ -5286,7 +5286,7 @@ message Instance {
   optional Status status = 181260274;
 
   // [Output Only] An optional, human-readable explanation of the status.
-  optional string status_message = 28992698;
+  optional string status_message = 297428154;
 
   // Tags to apply to this instance. Tags are used to identify valid sources or targets for network firewalls and are specified by the client during instance creation. The tags can be later modified by the setTags method. Each tag within the list must comply with RFC1035. Multiple tags can be specified via the 'tags.items' field.
   optional Tags tags = 3552281;
@@ -5321,7 +5321,7 @@ message InstanceAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -5359,7 +5359,7 @@ message InstanceGroup {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The fingerprint of the named ports. The system uses this fingerprint to detect conflicts when multiple users change the named ports concurrently.
   optional string fingerprint = 234678500;
@@ -5378,7 +5378,7 @@ message InstanceGroup {
   // This allows the system to reference ports by the assigned name instead of a port number. Named ports can also contain multiple ports. For example: [{name: "http", port: 80},{name: "http", port: 8080}]
   //
   // Named ports apply to all instances in this instance group.
-  repeated NamedPort named_ports = 159163276;
+  repeated NamedPort named_ports = 427598732;
 
   // [Output Only] The URL of the network to which all instances in the instance group belong. If your instance has multiple network interfaces, then the network and subnetwork fields only refer to the network and subnet used by your primary interface (nic0).
   optional string network = 232872494;
@@ -5387,13 +5387,13 @@ message InstanceGroup {
   optional string region = 138946292;
 
   // [Output Only] The URL for this instance group. The server generates this URL.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The total number of instances in the instance group.
   optional int32 size = 3530753;
 
   // [Output Only] The URL of the subnetwork to which all instances in the instance group belong. If your instance has multiple network interfaces, then the network and subnetwork fields only refer to the network and subnet used by your primary interface (nic0).
-  optional string subnetwork = 39392238;
+  optional string subnetwork = 307827694;
 
   // [Output Only] The URL of the zone where the instance group is located (for zonal resources).
   optional string zone = 3744684;
@@ -5403,7 +5403,7 @@ message InstanceGroup {
 //
 message InstanceGroupsScopedList {
   // [Output Only] The list of instance groups that are contained in this scope.
-  repeated InstanceGroup instance_groups = 98033854;
+  repeated InstanceGroup instance_groups = 366469310;
 
   // [Output Only] An informational warning that replaces the list of instance groups when the list is empty.
   optional Warning warning = 50704284;
@@ -5425,7 +5425,7 @@ message InstanceGroupAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -5450,7 +5450,7 @@ message InstanceGroupList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -5460,7 +5460,7 @@ message InstanceGroupList {
 //
 message InstanceGroupManagerAutoHealingPolicy {
   // The URL for the health check that signals autohealing.
-  optional string health_check = 40441189;
+  optional string health_check = 308876645;
 
   // The number of seconds that the managed instance group waits before it applies autohealing policies to new instances or recently recreated instances. This initial delay allows instances to initialize and run their startup scripts before the instance group determines that they are UNHEALTHY. This prevents the managed instance group from recreating its instances prematurely. This value must be from range [0, 3600].
   optional int32 initial_delay_sec = 263207002;
@@ -5470,7 +5470,7 @@ message InstanceGroupManagerAutoHealingPolicy {
 //
 message InstanceGroupManagerActionsSummary {
   // [Output Only] The total number of instances in the managed instance group that are scheduled to be abandoned. Abandoning an instance removes it from the managed instance group without deleting it.
-  optional int32 abandoning = 171587917;
+  optional int32 abandoning = 440023373;
 
   // [Output Only] The number of instances in the managed instance group that are scheduled to be created or are currently being created. If the group fails to create any of these instances, it tries again until it creates the instance successfully.
   //
@@ -5478,25 +5478,25 @@ message InstanceGroupManagerActionsSummary {
   optional int32 creating = 209809081;
 
   // [Output Only] The number of instances that the managed instance group will attempt to create. The group attempts to create each instance only once. If the group fails to create any of these instances, it decreases the group's targetSize value accordingly.
-  optional int32 creating_without_retries = 101481289;
+  optional int32 creating_without_retries = 369916745;
 
   // [Output Only] The number of instances in the managed instance group that are scheduled to be deleted or are currently being deleted.
-  optional int32 deleting = 14410664;
+  optional int32 deleting = 282846120;
 
   // [Output Only] The number of instances in the managed instance group that are running and have no scheduled actions.
   optional int32 none = 3387192;
 
   // [Output Only] The number of instances in the managed instance group that are scheduled to be recreated or are currently being being recreated. Recreating an instance deletes the existing root persistent disk and creates a new disk from the image that is defined in the instance template.
-  optional int32 recreating = 70621676;
+  optional int32 recreating = 339057132;
 
   // [Output Only] The number of instances in the managed instance group that are being reconfigured with properties that do not require a restart or a recreate action. For example, setting or removing target pools for the instance.
   optional int32 refreshing = 215044903;
 
   // [Output Only] The number of instances in the managed instance group that are scheduled to be restarted or are currently being restarted.
-  optional int32 restarting = 103877491;
+  optional int32 restarting = 372312947;
 
   // [Output Only] The number of instances in the managed instance group that are being verified. See the managedInstances[].currentAction property in the listManagedInstances method documentation.
-  optional int32 verifying = 183177417;
+  optional int32 verifying = 451612873;
 
 }
 
@@ -5509,7 +5509,7 @@ message StatefulPolicy {
 //
 message InstanceGroupManagerStatus {
   // [Output Only] The URL of the Autoscaler that targets this instance group manager.
-  optional string autoscaler = 248823511;
+  optional string autoscaler = 517258967;
 
   // [Output Only] A bit indicating whether the managed instance group is in a stable state. A stable state means that: none of the instances in the managed instance group is currently undergoing any type of change (for example, creation, restart, or deletion); no future changes are scheduled for instances in the managed instance group; and the managed instance group itself is not being modified.
   optional bool is_stable = 108410864;
@@ -5518,7 +5518,7 @@ message InstanceGroupManagerStatus {
   optional InstanceGroupManagerStatusStateful stateful = 244462412;
 
   // [Output Only] A status of consistency of Instances' versions with their target version specified by version field on Instance Group Manager.
-  optional InstanceGroupManagerStatusVersionTarget version_target = 20950744;
+  optional InstanceGroupManagerStatusVersionTarget version_target = 289386200;
 
 }
 
@@ -5527,12 +5527,12 @@ message InstanceGroupManagerUpdatePolicy {
   // The  instance redistribution policy for regional managed instance groups. Valid values are:
   // - PROACTIVE (default): The group attempts to maintain an even distribution of VM instances across zones in the region.
   // - NONE: For non-autoscaled groups, proactive redistribution is disabled.
-  optional string instance_redistribution_type = 24194968;
+  optional string instance_redistribution_type = 292630424;
 
   // The maximum number of instances that can be created above the specified targetSize during the update process. By default, a fixed value of 1 is used. This value can be either a fixed number or a percentage if the instance group has 10 or more instances. If you set a percentage, the number of instances will be rounded up if necessary.
   //
   // At least one of either maxSurge or maxUnavailable must be greater than 0. Learn more about maxSurge.
-  optional FixedOrPercent max_surge = 34137235;
+  optional FixedOrPercent max_surge = 302572691;
 
   // The maximum number of instances that can be unavailable during the update process. An instance is considered available if all of the following conditions are satisfied:
   //
@@ -5541,13 +5541,13 @@ message InstanceGroupManagerUpdatePolicy {
   // - If there is a health check on the instance group, the instance's liveness health check result must be HEALTHY at least once. If there is no health check on the group, then the instance only needs to have a status of RUNNING to be considered available.  By default, a fixed value of 1 is used. This value can be either a fixed number or a percentage if the instance group has 10 or more instances. If you set a percentage, the number of instances will be rounded up if necessary.
   //
   // At least one of either maxSurge or maxUnavailable must be greater than 0. Learn more about maxUnavailable.
-  optional FixedOrPercent max_unavailable = 136504821;
+  optional FixedOrPercent max_unavailable = 404940277;
 
   // Minimal action to be taken on an instance. You can specify either RESTART to restart existing instances or REPLACE to delete and create new instances from the target template. If you specify a RESTART, the Updater will attempt to perform that action only. However, if the Updater determines that the minimal action you specify is not enough to perform the update, it might perform a more disruptive action.
-  optional string minimal_action = 2131604;
+  optional string minimal_action = 270567060;
 
   // What action should be used to replace instances. See minimal_action.REPLACE
-  optional string replacement_method = 237496238;
+  optional string replacement_method = 505931694;
 
   // The type of update process. You can specify either PROACTIVE so that the instance group manager proactively executes actions in order to bring instances to their target versions or OPPORTUNISTIC so that no action is proactively executed but the update will be performed as part of other actions (for example, resizes or recreateInstances calls).
   optional string type = 3575610;
@@ -5557,7 +5557,7 @@ message InstanceGroupManagerUpdatePolicy {
 //
 message InstanceGroupManagerVersion {
   // The URL of the instance template that is specified for this managed instance group. The group uses this template to create new instances in the managed instance group until the `targetSize` for this version is reached. The templates for existing instances in the group do not change unless you run recreateInstances, run applyUpdatesToInstances, or set the group's updatePolicy.type to PROACTIVE; in those cases, existing instances are updated until the `targetSize` for this version is reached.
-  optional string instance_template = 40812772;
+  optional string instance_template = 309248228;
 
   // Name of the version. Unique among all versions in the scope of this managed instance group.
   optional string name = 3373707;
@@ -5578,10 +5578,10 @@ message InstanceGroupManagerVersion {
 // For regional Managed Instance Group, use the regionInstanceGroupManagers resource. (== resource_for {$api_version}.instanceGroupManagers ==) (== resource_for {$api_version}.regionInstanceGroupManagers ==)
 message InstanceGroupManager {
   // The autohealing policy for this managed instance group. You can specify only one value.
-  repeated InstanceGroupManagerAutoHealingPolicy auto_healing_policies = 188363653;
+  repeated InstanceGroupManagerAutoHealingPolicy auto_healing_policies = 456799109;
 
   // The base instance name to use for instances in this group. The value must be 1-58 characters long. Instances are named by appending a hyphen and a random four-character string to the base instance name. The base instance name must comply with RFC1035.
-  optional string base_instance_name = 120670983;
+  optional string base_instance_name = 389106439;
 
   // [Output Only] The creation timestamp for this managed instance group in RFC3339 text format.
   optional string creation_timestamp = 30525366;
@@ -5590,10 +5590,10 @@ message InstanceGroupManager {
   optional InstanceGroupManagerActionsSummary current_actions = 164045879;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Policy specifying the intended distribution of managed instances across zones in a regional managed instance group.
-  optional DistributionPolicy distribution_policy = 266123085;
+  optional DistributionPolicy distribution_policy = 534558541;
 
   // Fingerprint of this resource. This field may be used in optimistic locking. It will be ignored when inserting an InstanceGroupManager. An up-to-date fingerprint must be provided in order to update the InstanceGroupManager, otherwise the request will fail with error 412 conditionNotMet.
   //
@@ -5607,7 +5607,7 @@ message InstanceGroupManager {
   optional string instance_group = 81095253;
 
   // The URL of the instance template that is specified for this managed instance group. The group uses this template to create all new instances in the managed instance group. The templates for existing instances in the group do not change unless you run recreateInstances, run applyUpdatesToInstances, or set the group's updatePolicy.type to PROACTIVE.
-  optional string instance_template = 40812772;
+  optional string instance_template = 309248228;
 
   // [Output Only] The resource type, which is always compute#instanceGroupManager for managed instance groups.
   optional string kind = 3292052;
@@ -5616,13 +5616,13 @@ message InstanceGroupManager {
   optional string name = 3373707;
 
   // Named ports configured for the Instance Groups complementary to this Instance Group Manager.
-  repeated NamedPort named_ports = 159163276;
+  repeated NamedPort named_ports = 427598732;
 
   // [Output Only] The URL of the region where the managed instance group resides (for regional resources).
   optional string region = 138946292;
 
   // [Output Only] The URL for this managed instance group. The server defines this URL.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // Stateful configuration for this Instanced Group Manager
   optional StatefulPolicy stateful_policy = 47538565;
@@ -5631,7 +5631,7 @@ message InstanceGroupManager {
   optional InstanceGroupManagerStatus status = 181260274;
 
   // The URLs for all TargetPool resources to which instances in the instanceGroup field are added. The target pools automatically apply to all of the instances in the managed instance group.
-  repeated string target_pools = 67637161;
+  repeated string target_pools = 336072617;
 
   // The target number of running instances for this managed instance group. You can reduce this number by using the instanceGroupManager deleteInstances or abandonInstances methods. Resizing the group also changes this number.
   optional int32 target_size = 62880239;
@@ -5674,7 +5674,7 @@ message InstanceGroupManagerAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -5699,7 +5699,7 @@ message InstanceGroupManagerList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -5712,21 +5712,21 @@ message InstanceGroupManagerStatusStateful {
   optional bool has_stateful_config = 110474224;
 
   // [Output Only] Status of per-instance configs on the instance.
-  optional InstanceGroupManagerStatusStatefulPerInstanceConfigs per_instance_configs = 257829545;
+  optional InstanceGroupManagerStatusStatefulPerInstanceConfigs per_instance_configs = 526265001;
 
 }
 
 //
 message InstanceGroupManagerStatusVersionTarget {
   // [Output Only] A bit indicating whether version target has been reached in this managed instance group, i.e. all instances are in their target version. Instances' target version are specified by version field on Instance Group Manager.
-  optional bool is_reached = 164773693;
+  optional bool is_reached = 433209149;
 
 }
 
 //
 message InstanceGroupManagerStatusStatefulPerInstanceConfigs {
   // A bit indicating if all of the group's per-instance configs (listed in the output of a listPerInstanceConfigs API call) have status EFFECTIVE or there are no per-instance-configs.
-  optional bool all_effective = 248105097;
+  optional bool all_effective = 516540553;
 
 }
 
@@ -5740,7 +5740,7 @@ message InstanceGroupManagersAbandonInstancesRequest {
 // InstanceGroupManagers.applyUpdatesToInstances
 message InstanceGroupManagersApplyUpdatesRequest {
   // Flag to update all instances instead of specified list of ?instances?. If the flag is set to true then the instances may not be specified in the request.
-  optional bool all_instances = 135241056;
+  optional bool all_instances = 403676512;
 
   // The list of URLs of one or more instances for which you want to apply updates. Each URL can be a full URL or a partial URL, such as zones/[ZONE]/instances/[INSTANCE_NAME].
   repeated string instances = 29097598;
@@ -5750,7 +5750,7 @@ message InstanceGroupManagersApplyUpdatesRequest {
   // - RESTART: Stop the instance and start it again.
   // - REFRESH: Do not stop the instance.
   // - NONE: Do not disrupt the instance at all.  By default, the minimum action is NONE. If your update requires a more disruptive action than you set with this flag, the necessary action is performed to execute the update.
-  optional string minimal_action = 2131604;
+  optional string minimal_action = 270567060;
 
   // The most disruptive action that you want to perform on each instance during the update:
   // - REPLACE: Delete the instance and create it again.
@@ -5768,17 +5768,17 @@ message PerInstanceConfig {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    APPLYING = 83568052;
+    APPLYING = 352003508;
 
-    DELETING = 260166568;
+    DELETING = 528602024;
 
     EFFECTIVE = 244201863;
 
     NONE = 2402104;
 
-    UNAPPLIED = 215499684;
+    UNAPPLIED = 483935140;
 
-    UNAPPLIED_DELETION = 45521417;
+    UNAPPLIED_DELETION = 313956873;
 
   }
 
@@ -5823,7 +5823,7 @@ message InstanceManagedByIgmError {
   optional InstanceManagedByIgmErrorManagedInstanceError error = 96784904;
 
   // [Output Only] Details of the instance action that triggered this error. May be null, if the error was not caused by an action on an instance. This field is optional.
-  optional InstanceManagedByIgmErrorInstanceActionDetails instance_action_details = 23789091;
+  optional InstanceManagedByIgmErrorInstanceActionDetails instance_action_details = 292224547;
 
   // [Output Only] The time that this error occurred. This value is in RFC3339 text format.
   optional string timestamp = 55126294;
@@ -5856,21 +5856,21 @@ message ManagedInstance {
     // A value indicating that the enum field is not set.
     UNDEFINED_CURRENT_ACTION = 0;
 
-    ABANDONING = 119809357;
+    ABANDONING = 388244813;
 
-    CREATING = 187129529;
+    CREATING = 455564985;
 
-    CREATING_WITHOUT_RETRIES = 160408329;
+    CREATING_WITHOUT_RETRIES = 428843785;
 
-    DELETING = 260166568;
+    DELETING = 528602024;
 
     NONE = 2402104;
 
-    RECREATING = 18843116;
+    RECREATING = 287278572;
 
     REFRESHING = 163266343;
 
-    RESTARTING = 52098931;
+    RESTARTING = 320534387;
 
     VERIFYING = 16982185;
 
@@ -5881,23 +5881,23 @@ message ManagedInstance {
     // A value indicating that the enum field is not set.
     UNDEFINED_INSTANCE_STATUS = 0;
 
-    DEPROVISIONING = 160500206;
+    DEPROVISIONING = 428935662;
 
-    PROVISIONING = 22461165;
+    PROVISIONING = 290896621;
 
-    REPAIRING = 145047829;
+    REPAIRING = 413483285;
 
     RUNNING = 121282975;
 
-    STAGING = 162636827;
+    STAGING = 431072283;
 
-    STOPPED = 175840685;
+    STOPPED = 444276141;
 
-    STOPPING = 82356340;
+    STOPPING = 350791796;
 
     SUSPENDED = 51223995;
 
-    SUSPENDING = 245770790;
+    SUSPENDING = 514206246;
 
     TERMINATED = 250018339;
 
@@ -5922,29 +5922,29 @@ message ManagedInstance {
   optional string instance = 18257045;
 
   // [Output Only] Health state of the instance per health-check.
-  repeated ManagedInstanceInstanceHealth instance_health = 114231622;
+  repeated ManagedInstanceInstanceHealth instance_health = 382667078;
 
   // [Output Only] The status of the instance. This field is empty when the instance does not exist.
   optional InstanceStatus instance_status = 174577372;
 
   // [Output Only] Information about the last attempt to create or delete the instance.
-  optional ManagedInstanceLastAttempt last_attempt = 166336036;
+  optional ManagedInstanceLastAttempt last_attempt = 434771492;
 
   // [Output Only] Preserved state applied from per-instance config for this instance.
   optional PreservedState preserved_state_from_config = 98661858;
 
   // [Output Only] Preserved state generated based on stateful policy for this instance.
-  optional PreservedState preserved_state_from_policy = 202348498;
+  optional PreservedState preserved_state_from_policy = 470783954;
 
   // [Output Only] Intended version of this instance.
-  optional ManagedInstanceVersion version = 83172568;
+  optional ManagedInstanceVersion version = 351608024;
 
 }
 
 //
 message InstanceGroupManagersListManagedInstancesResponse {
   // [Output Only] The list of instances in the managed instance group.
-  repeated ManagedInstance managed_instances = 67784158;
+  repeated ManagedInstance managed_instances = 336219614;
 
   // [Output Only] This token allows you to get the next page of results for list requests. If the number of results is larger than maxResults, use the nextPageToken as a value for the query parameter pageToken in the next list request. Subsequent list requests will have their own nextPageToken to continue paging through the results.
   optional string next_page_token = 79797525;
@@ -5967,7 +5967,7 @@ message InstanceGroupManagersListPerInstanceConfigsResp {
 // InstanceGroupManagers.patchPerInstanceConfigs
 message InstanceGroupManagersPatchPerInstanceConfigsReq {
   // The list of per-instance configs to insert or patch on this managed instance group.
-  repeated PerInstanceConfig per_instance_configs = 257829545;
+  repeated PerInstanceConfig per_instance_configs = 526265001;
 
 }
 
@@ -5981,7 +5981,7 @@ message InstanceGroupManagersRecreateInstancesRequest {
 //
 message InstanceGroupManagersSetInstanceTemplateRequest {
   // The URL of the instance template that is specified for this managed instance group. The group uses this template to create all new instances in the managed instance group. The templates for existing instances in the group do not change unless you run recreateInstances, run applyUpdatesToInstances, or set the group's updatePolicy.type to PROACTIVE.
-  optional string instance_template = 40812772;
+  optional string instance_template = 309248228;
 
 }
 
@@ -5991,14 +5991,14 @@ message InstanceGroupManagersSetTargetPoolsRequest {
   optional string fingerprint = 234678500;
 
   // The list of target pool URLs that instances in this managed instance group belong to. The managed instance group applies these target pools to all of the instances in the group. Existing instances and new instances in the group all receive these target pool settings.
-  repeated string target_pools = 67637161;
+  repeated string target_pools = 336072617;
 
 }
 
 // InstanceGroupManagers.updatePerInstanceConfigs
 message InstanceGroupManagersUpdatePerInstanceConfigsReq {
   // The list of per-instance configs to insert or patch on this managed instance group.
-  repeated PerInstanceConfig per_instance_configs = 257829545;
+  repeated PerInstanceConfig per_instance_configs = 526265001;
 
 }
 
@@ -6023,23 +6023,23 @@ message InstanceWithNamedPorts {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    DEPROVISIONING = 160500206;
+    DEPROVISIONING = 428935662;
 
-    PROVISIONING = 22461165;
+    PROVISIONING = 290896621;
 
-    REPAIRING = 145047829;
+    REPAIRING = 413483285;
 
     RUNNING = 121282975;
 
-    STAGING = 162636827;
+    STAGING = 431072283;
 
-    STOPPED = 175840685;
+    STOPPED = 444276141;
 
-    STOPPING = 82356340;
+    STOPPING = 350791796;
 
     SUSPENDED = 51223995;
 
-    SUSPENDING = 245770790;
+    SUSPENDING = 514206246;
 
     TERMINATED = 250018339;
 
@@ -6049,7 +6049,7 @@ message InstanceWithNamedPorts {
   optional string instance = 18257045;
 
   // [Output Only] The named ports that belong to this instance group.
-  repeated NamedPort named_ports = 159163276;
+  repeated NamedPort named_ports = 427598732;
 
   // [Output Only] The status of the instance.
   optional Status status = 181260274;
@@ -6071,7 +6071,7 @@ message InstanceGroupsListInstances {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -6109,7 +6109,7 @@ message InstanceGroupsSetNamedPortsRequest {
   optional string fingerprint = 234678500;
 
   // The list of named ports to set for this instance group.
-  repeated NamedPort named_ports = 159163276;
+  repeated NamedPort named_ports = 427598732;
 
 }
 
@@ -6128,7 +6128,7 @@ message InstanceList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -6145,7 +6145,7 @@ message Reference {
   optional string reference_type = 247521198;
 
   // URL of the resource which refers to the target.
-  optional string referrer = 82738207;
+  optional string referrer = 351173663;
 
   // URL of the resource to which this reference points.
   optional string target = 192835985;
@@ -6167,7 +6167,7 @@ message InstanceListReferrers {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -6180,7 +6180,7 @@ message InstanceManagedByIgmErrorManagedInstanceError {
   optional string code = 3059181;
 
   // [Output Only] Error message.
-  optional string message = 149618695;
+  optional string message = 418054151;
 
 }
 
@@ -6191,21 +6191,21 @@ message InstanceManagedByIgmErrorInstanceActionDetails {
     // A value indicating that the enum field is not set.
     UNDEFINED_ACTION = 0;
 
-    ABANDONING = 119809357;
+    ABANDONING = 388244813;
 
-    CREATING = 187129529;
+    CREATING = 455564985;
 
-    CREATING_WITHOUT_RETRIES = 160408329;
+    CREATING_WITHOUT_RETRIES = 428843785;
 
-    DELETING = 260166568;
+    DELETING = 528602024;
 
     NONE = 2402104;
 
-    RECREATING = 18843116;
+    RECREATING = 287278572;
 
     REFRESHING = 163266343;
 
-    RESTARTING = 52098931;
+    RESTARTING = 320534387;
 
     VERIFYING = 16982185;
 
@@ -6218,14 +6218,14 @@ message InstanceManagedByIgmErrorInstanceActionDetails {
   optional string instance = 18257045;
 
   // [Output Only] Version this instance was created from, or was being created from, but the creation failed. Corresponds to one of the versions that were set on the Instance Group Manager resource at the time this instance was being created.
-  optional ManagedInstanceVersion version = 83172568;
+  optional ManagedInstanceVersion version = 351608024;
 
 }
 
 //
 message ManagedInstanceVersion {
   // [Output Only] The intended template of the instance. This field is empty when current_action is one of { DELETING, ABANDONING }.
-  optional string instance_template = 40812772;
+  optional string instance_template = 309248228;
 
   // [Output Only] Name of the version.
   optional string name = 3373707;
@@ -6244,7 +6244,7 @@ message InstanceMoveRequest {
   // - https://www.googleapis.com/compute/v1/projects/project/zones/zone/instances/instance
   // - projects/project/zones/zone/instances/instance
   // - zones/zone/instances/instance
-  optional string target_instance = 21333891;
+  optional string target_instance = 289769347;
 
 }
 
@@ -6255,31 +6255,31 @@ message InstanceProperties {
     // A value indicating that the enum field is not set.
     UNDEFINED_PRIVATE_IPV6_GOOGLE_ACCESS = 0;
 
-    ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE = 159540538;
+    ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE = 427975994;
 
-    ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE = 19774807;
+    ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE = 288210263;
 
-    INHERIT_FROM_SUBNETWORK = 261821503;
+    INHERIT_FROM_SUBNETWORK = 530256959;
 
   }
 
   // Enables instances created based on these properties to send packets with source IP addresses other than their own and receive packets with destination IP addresses other than their own. If these instances will be used as an IP gateway or it will be set as the next-hop in a Route resource, specify true. If unsure, leave this set to false. See the Enable IP forwarding documentation for more information.
-  optional bool can_ip_forward = 199295868;
+  optional bool can_ip_forward = 467731324;
 
   // Specifies the Confidential Instance options.
-  optional ConfidentialInstanceConfig confidential_instance_config = 222202229;
+  optional ConfidentialInstanceConfig confidential_instance_config = 490637685;
 
   // An optional text description for the instances that are created from these properties.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // An array of disks that are associated with the instances that are created from these properties.
   repeated AttachedDisk disks = 95594102;
 
   // A list of guest accelerator cards' type and count to use for instances created from these properties.
-  repeated AcceleratorConfig guest_accelerators = 195159663;
+  repeated AcceleratorConfig guest_accelerators = 463595119;
 
   // Labels to apply to instances that are created from these properties.
-  map<string, string> labels = 231759871;
+  map<string, string> labels = 500195327;
 
   // The machine type to use for instances that are created from these properties.
   optional string machine_type = 227711026;
@@ -6303,10 +6303,10 @@ message InstanceProperties {
   repeated string resource_policies = 22220385;
 
   // Specifies the scheduling options for the instances that are created from these properties.
-  optional Scheduling scheduling = 118252948;
+  optional Scheduling scheduling = 386688404;
 
   // A list of service accounts with specified scopes. Access tokens for these service accounts are available to the instances that are created from these properties. Use metadata queries to obtain the access tokens for these instances.
-  repeated ServiceAccount service_accounts = 9101872;
+  repeated ServiceAccount service_accounts = 277537328;
 
   optional ShieldedInstanceConfig shielded_instance_config = 12862901;
 
@@ -6330,7 +6330,7 @@ message InstanceTemplate {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] A unique identifier for this instance template. The server defines this identifier.
   optional string id = 3355;
@@ -6345,12 +6345,12 @@ message InstanceTemplate {
   optional InstanceProperties properties = 147688755;
 
   // [Output Only] The URL for this instance template. The server defines this URL.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // The source instance used to create the template. You can provide this as a partial or full URL to the resource. For example, the following are valid values:
   // - https://www.googleapis.com/compute/v1/projects/project/zones/zone/instances/instance
   // - projects/project/zones/zone/instances/instance
-  optional string source_instance = 127880249;
+  optional string source_instance = 396315705;
 
   // The source instance params to use to create this instance template.
   optional SourceInstanceParams source_instance_params = 135342156;
@@ -6372,7 +6372,7 @@ message InstanceTemplateList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -6398,14 +6398,14 @@ message InstancesSetLabelsRequest {
   // Fingerprint of the previous set of labels for this resource, used to prevent conflicts. Provide the latest fingerprint value when making a request to add or change labels.
   optional string label_fingerprint = 178124825;
 
-  map<string, string> labels = 231759871;
+  map<string, string> labels = 500195327;
 
 }
 
 //
 message InstancesSetMachineResourcesRequest {
   // A list of the type and count of accelerator cards attached to the instance.
-  repeated AcceleratorConfig guest_accelerators = 195159663;
+  repeated AcceleratorConfig guest_accelerators = 463595119;
 
 }
 
@@ -6453,7 +6453,7 @@ message InterconnectCircuitInfo {
   optional string google_circuit_id = 262014711;
 
   // Google-side demarc ID for this circuit. Assigned at circuit turn-up and provided by Google to the customer in the LOA.
-  optional string google_demarc_id = 179760814;
+  optional string google_demarc_id = 448196270;
 
 }
 
@@ -6482,9 +6482,9 @@ message InterconnectOutageNotification {
     // A value indicating that the enum field is not set.
     UNDEFINED_SOURCE = 0;
 
-    GOOGLE = 229003833;
+    GOOGLE = 497439289;
 
-    NSRC_GOOGLE = 242139106;
+    NSRC_GOOGLE = 510574562;
 
   }
 
@@ -6495,15 +6495,15 @@ message InterconnectOutageNotification {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATE = 0;
 
-    ACTIVE = 46297862;
+    ACTIVE = 314733318;
 
     CANCELLED = 41957681;
 
-    COMPLETED = 41485867;
+    COMPLETED = 309921323;
 
     NS_ACTIVE = 252563136;
 
-    NS_CANCELED = 238143955;
+    NS_CANCELED = 506579411;
 
   }
 
@@ -6511,7 +6511,7 @@ message InterconnectOutageNotification {
   repeated string affected_circuits = 177717013;
 
   // A description about the purpose of the outage.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Scheduled end time for the outage (milliseconds since Unix epoch).
   optional string end_time = 114938801;
@@ -6519,7 +6519,7 @@ message InterconnectOutageNotification {
   // Form this outage is expected to take, which can take one of the following values:
   // - OUTAGE: The Interconnect may be completely out of service for some or all of the specified window.
   // - PARTIAL_OUTAGE: Some circuits comprising the Interconnect as a whole should remain up, but with reduced bandwidth. Note that the versions of this enum prefixed with "IT_" have been deprecated in favor of the unprefixed values.
-  optional IssueType issue_type = 101203680;
+  optional IssueType issue_type = 369639136;
 
   // Unique identifier for this outage notification.
   optional string name = 3373707;
@@ -6551,9 +6551,9 @@ message Interconnect {
 
     DEDICATED = 258411983;
 
-    IT_PRIVATE = 67241551;
+    IT_PRIVATE = 335677007;
 
-    PARTNER = 193489064;
+    PARTNER = 461924520;
 
   }
 
@@ -6564,7 +6564,7 @@ message Interconnect {
     // A value indicating that the enum field is not set.
     UNDEFINED_LINK_TYPE = 0;
 
-    LINK_TYPE_ETHERNET_100G_LR = 69237095;
+    LINK_TYPE_ETHERNET_100G_LR = 337672551;
 
     LINK_TYPE_ETHERNET_10G_LR = 236739749;
 
@@ -6592,14 +6592,14 @@ message Interconnect {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATE = 0;
 
-    ACTIVE = 46297862;
+    ACTIVE = 314733318;
 
-    UNPROVISIONED = 248898523;
+    UNPROVISIONED = 517333979;
 
   }
 
   // Administrative status of the interconnect. When this is set to true, the Interconnect is functional and can carry traffic. When set to false, no packets can be carried over the interconnect and no BGP routes are exchanged over it. By default, the status is set to true.
-  optional bool admin_enabled = 177239633;
+  optional bool admin_enabled = 445675089;
 
   // [Output Only] A list of CircuitInfo objects, that describe the individual circuits in this LAG.
   repeated InterconnectCircuitInfo circuit_infos = 164839855;
@@ -6611,27 +6611,27 @@ message Interconnect {
   optional string customer_name = 3665484;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] A list of outages expected for this Interconnect.
   repeated InterconnectOutageNotification expected_outages = 264484123;
 
   // [Output Only] IP address configured on the Google side of the Interconnect link. This can be used only for ping tests.
-  optional string google_ip_address = 174670498;
+  optional string google_ip_address = 443105954;
 
   // [Output Only] Google reference ID to be used when raising support tickets with Google or otherwise to debug backend connectivity issues.
-  optional string google_reference_id = 266509013;
+  optional string google_reference_id = 534944469;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
 
   // [Output Only] A list of the URLs of all InterconnectAttachments configured to use this Interconnect.
-  repeated string interconnect_attachments = 156952959;
+  repeated string interconnect_attachments = 425388415;
 
   // Type of interconnect, which can take one of the following values:
   // - PARTNER: A partner-managed interconnection shared between customers though a partner.
   // - DEDICATED: A dedicated physical interconnection with the customer. Note that a value IT_PRIVATE has been deprecated in favor of DEDICATED.
-  optional InterconnectType interconnect_type = 246729803;
+  optional InterconnectType interconnect_type = 515165259;
 
   // [Output Only] Type of the resource. Always compute#interconnect for interconnects.
   optional string kind = 3292052;
@@ -6639,10 +6639,10 @@ message Interconnect {
   // Type of link requested, which can take one of the following values:
   // - LINK_TYPE_ETHERNET_10G_LR: A 10G Ethernet with LR optics
   // - LINK_TYPE_ETHERNET_100G_LR: A 100G Ethernet with LR optics. Note that this field indicates the speed of each of the links in the bundle, not the speed of the entire bundle.
-  optional LinkType link_type = 254772319;
+  optional LinkType link_type = 523207775;
 
   // URL of the InterconnectLocation object that represents where this connection is to be provisioned.
-  optional string location = 21995445;
+  optional string location = 290430901;
 
   // Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
   optional string name = 3373707;
@@ -6660,13 +6660,13 @@ message Interconnect {
   optional string peer_ip_address = 207735769;
 
   // [Output Only] Number of links actually provisioned in this interconnect.
-  optional int32 provisioned_link_count = 142453109;
+  optional int32 provisioned_link_count = 410888565;
 
   // Target number of physical links in the link bundle, as requested by the customer.
   optional int32 requested_link_count = 45051387;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The current state of Interconnect functionality, which can take one of the following values:
   // - ACTIVE: The Interconnect is valid, turned up and ready to use. Attachments may be provisioned on this Interconnect.
@@ -6679,20 +6679,20 @@ message Interconnect {
 // Informational metadata about Partner attachments from Partners to display to customers. These fields are propagated from PARTNER_PROVIDER attachments to their corresponding PARTNER attachments.
 message InterconnectAttachmentPartnerMetadata {
   // Plain text name of the Interconnect this attachment is connected to, as displayed in the Partner's portal. For instance "Chicago 1". This value may be validated to match approved Partner values.
-  optional string interconnect_name = 246527900;
+  optional string interconnect_name = 514963356;
 
   // Plain text name of the Partner providing this attachment. This value may be validated to match approved Partner values.
   optional string partner_name = 161747874;
 
   // URL of the Partner's portal for this Attachment. Partners may customise this to be a deep link to the specific resource on the Partner portal. This value may be validated to match approved Partner values.
-  optional string portal_url = 747292;
+  optional string portal_url = 269182748;
 
 }
 
 // Information for an interconnect attachment when this belongs to an interconnect of type DEDICATED.
 message InterconnectAttachmentPrivateInfo {
   // [Output Only] 802.1q encapsulation tag to be used for traffic between Google and the customer, going to and from this network and region.
-  optional uint32 tag8021q = 3385536;
+  optional uint32 tag8021q = 271820992;
 
 }
 
@@ -6719,15 +6719,15 @@ message InterconnectAttachment {
 
     BPS_100M = 49547958;
 
-    BPS_10G = 10257550;
+    BPS_10G = 278693006;
 
-    BPS_1G = 86922992;
+    BPS_1G = 355358448;
 
     BPS_200M = 49577749;
 
-    BPS_20G = 10258511;
+    BPS_20G = 278693967;
 
-    BPS_2G = 86923023;
+    BPS_2G = 355358479;
 
     BPS_300M = 49607540;
 
@@ -6735,11 +6735,11 @@ message InterconnectAttachment {
 
     BPS_500M = 49667122;
 
-    BPS_50G = 10261394;
+    BPS_50G = 278696850;
 
-    BPS_50M = 10261400;
+    BPS_50M = 278696856;
 
-    BPS_5G = 86923116;
+    BPS_5G = 355358572;
 
   }
 
@@ -6751,11 +6751,11 @@ message InterconnectAttachment {
     // A value indicating that the enum field is not set.
     UNDEFINED_EDGE_AVAILABILITY_DOMAIN = 0;
 
-    AVAILABILITY_DOMAIN_1 = 81116634;
+    AVAILABILITY_DOMAIN_1 = 349552090;
 
-    AVAILABILITY_DOMAIN_2 = 81116635;
+    AVAILABILITY_DOMAIN_2 = 349552091;
 
-    AVAILABILITY_DOMAIN_ANY = 106820917;
+    AVAILABILITY_DOMAIN_ANY = 375256373;
 
   }
 
@@ -6783,19 +6783,19 @@ message InterconnectAttachment {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATE = 0;
 
-    ACTIVE = 46297862;
+    ACTIVE = 314733318;
 
     DEFUNCT = 115891759;
 
-    PARTNER_REQUEST_RECEIVED = 245151848;
+    PARTNER_REQUEST_RECEIVED = 513587304;
 
     PENDING_CUSTOMER = 167494054;
 
-    PENDING_PARTNER = 119455200;
+    PENDING_PARTNER = 387890656;
 
-    STATE_UNSPECIFIED = 202319945;
+    STATE_UNSPECIFIED = 470755401;
 
-    UNPROVISIONED = 248898523;
+    UNPROVISIONED = 517333979;
 
   }
 
@@ -6809,14 +6809,14 @@ message InterconnectAttachment {
 
     DEDICATED = 258411983;
 
-    PARTNER = 193489064;
+    PARTNER = 461924520;
 
-    PARTNER_PROVIDER = 214825896;
+    PARTNER_PROVIDER = 483261352;
 
   }
 
   // Determines whether this Attachment will carry packets. Not present for PARTNER_PROVIDER.
-  optional bool admin_enabled = 177239633;
+  optional bool admin_enabled = 445675089;
 
   // Provisioned bandwidth capacity for the interconnect attachment. For attachments of type DEDICATED, the user can set the bandwidth. For attachments of type PARTNER, the Google Partner that is operating the interconnect must set the bandwidth. Output only for PARTNER type, mutable for PARTNER_PROVIDER and DEDICATED, and can take one of the following values:
   // - BPS_50M: 50 Mbit/s
@@ -6837,19 +6837,19 @@ message InterconnectAttachment {
   repeated string candidate_subnets = 237842938;
 
   // [Output Only] IPv4 address + prefix length to be configured on Cloud Router Interface for this interconnect attachment.
-  optional string cloud_router_ip_address = 18957320;
+  optional string cloud_router_ip_address = 287392776;
 
   // [Output Only] Creation timestamp in RFC3339 text format.
   optional string creation_timestamp = 30525366;
 
   // [Output Only] IPv4 address + prefix length to be configured on the customer router subinterface for this interconnect attachment.
-  optional string customer_router_ip_address = 64040305;
+  optional string customer_router_ip_address = 332475761;
 
   // [Output Only] Dataplane version for this InterconnectAttachment.
   optional int32 dataplane_version = 34920075;
 
   // An optional description of this resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Desired availability domain for the attachment. Only available for type PARTNER, at creation time, and can take one of the following values:
   // - AVAILABILITY_DOMAIN_ANY
@@ -6858,7 +6858,7 @@ message InterconnectAttachment {
   optional EdgeAvailabilityDomain edge_availability_domain = 71289510;
 
   // [Output Only] Google reference ID, to be used when raising support tickets with Google or otherwise to debug backend connectivity issues. [Deprecated] This field is not used.
-  optional string google_reference_id = 266509013;
+  optional string google_reference_id = 534944469;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -6881,10 +6881,10 @@ message InterconnectAttachment {
   optional OperationalStatus operational_status = 201070847;
 
   // [Output only for type PARTNER. Input only for PARTNER_PROVIDER. Not present for DEDICATED]. The opaque identifier of an PARTNER attachment used to initiate provisioning with a selected partner. Of the form "XXXXX/region/domain"
-  optional string pairing_key = 171260008;
+  optional string pairing_key = 439695464;
 
   // Optional BGP ASN for the router supplied by a Layer 3 Partner if they configured BGP on behalf of the customer. Output only for PARTNER type, input only for PARTNER_PROVIDER, not available for DEDICATED.
-  optional string partner_asn = 169730693;
+  optional string partner_asn = 438166149;
 
   // Informational metadata about Partner attachments from Partners to display to customers. Output only for for PARTNER type, mutable for PARTNER_PROVIDER, not available for DEDICATED.
   optional InterconnectAttachmentPartnerMetadata partner_metadata = 65908934;
@@ -6899,7 +6899,7 @@ message InterconnectAttachment {
   optional string router = 148608841;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The current state of this attachment's functionality. Enum values ACTIVE and UNPROVISIONED are shared by DEDICATED/PRIVATE, PARTNER, and PARTNER_PROVIDER interconnect attachments, while enum values PENDING_PARTNER, PARTNER_REQUEST_RECEIVED, and PENDING_CUSTOMER are used for only PARTNER and PARTNER_PROVIDER interconnect attachments. This state can take one of the following values:
   // - ACTIVE: The attachment has been turned up and is ready to use.
@@ -6924,7 +6924,7 @@ message InterconnectAttachment {
 //
 message InterconnectAttachmentsScopedList {
   // A list of interconnect attachments contained in this scope.
-  repeated InterconnectAttachment interconnect_attachments = 156952959;
+  repeated InterconnectAttachment interconnect_attachments = 425388415;
 
   // Informational warning which replaces the list of addresses when the list is empty.
   optional Warning warning = 50704284;
@@ -6946,7 +6946,7 @@ message InterconnectAttachmentAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -6971,7 +6971,7 @@ message InterconnectAttachmentList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -6981,17 +6981,17 @@ message InterconnectAttachmentList {
 // Describing the ARP neighbor entries seen on this link
 message InterconnectDiagnosticsARPEntry {
   // The IP address of this ARP neighbor.
-  optional string ip_address = 137836764;
+  optional string ip_address = 406272220;
 
   // The MAC address of this ARP neighbor.
-  optional string mac_address = 64104708;
+  optional string mac_address = 332540164;
 
 }
 
 //
 message InterconnectDiagnosticsLinkStatus {
   // A list of InterconnectDiagnostics.ARPEntry objects, describing the ARP neighbor entries seen on this link. This will be empty if the link is bundled
-  repeated InterconnectDiagnosticsARPEntry arp_caches = 146156305;
+  repeated InterconnectDiagnosticsARPEntry arp_caches = 414591761;
 
   // The unique ID for this link assigned during turn up by Google.
   optional string circuit_id = 225180977;
@@ -6999,26 +6999,26 @@ message InterconnectDiagnosticsLinkStatus {
   // The Demarc address assigned by Google and provided in the LoA.
   optional string google_demarc = 51084;
 
-  optional InterconnectDiagnosticsLinkLACPStatus lacp_status = 92774959;
+  optional InterconnectDiagnosticsLinkLACPStatus lacp_status = 361210415;
 
   // An InterconnectDiagnostics.LinkOpticalPower object, describing the current value and status of the received light level.
   optional InterconnectDiagnosticsLinkOpticalPower receiving_optical_power = 244717279;
 
   // An InterconnectDiagnostics.LinkOpticalPower object, describing the current value and status of the transmitted light level.
-  optional InterconnectDiagnosticsLinkOpticalPower transmitting_optical_power = 190995741;
+  optional InterconnectDiagnosticsLinkOpticalPower transmitting_optical_power = 459431197;
 
 }
 
 // Diagnostics information about interconnect, contains detailed and current technical information about Google's side of the connection.
 message InterconnectDiagnostics {
   // A list of InterconnectDiagnostics.ARPEntry objects, describing individual neighbors currently seen by the Google router in the ARP cache for the Interconnect. This will be empty when the Interconnect is not bundled.
-  repeated InterconnectDiagnosticsARPEntry arp_caches = 146156305;
+  repeated InterconnectDiagnosticsARPEntry arp_caches = 414591761;
 
   // A list of InterconnectDiagnostics.LinkStatus objects, describing the status for each link on the Interconnect.
   repeated InterconnectDiagnosticsLinkStatus links = 102977465;
 
   // The MAC address of the Interconnect's bundle interface.
-  optional string mac_address = 64104708;
+  optional string mac_address = 332540164;
 
 }
 
@@ -7031,7 +7031,7 @@ message InterconnectDiagnosticsLinkLACPStatus {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATE = 0;
 
-    ACTIVE = 46297862;
+    ACTIVE = 314733318;
 
     DETACHED = 216562546;
 
@@ -7041,7 +7041,7 @@ message InterconnectDiagnosticsLinkLACPStatus {
   optional string google_system_id = 91210405;
 
   // System ID of the port on the neighbor's side of the LACP exchange.
-  optional string neighbor_system_id = 75385886;
+  optional string neighbor_system_id = 343821342;
 
   // The state of a LACP link, which can take one of the following values:
   // - ACTIVE: The link is configured and active within the bundle.
@@ -7062,13 +7062,13 @@ message InterconnectDiagnosticsLinkOpticalPower {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATE = 0;
 
-    HIGH_ALARM = 36927828;
+    HIGH_ALARM = 305363284;
 
     HIGH_WARNING = 220984799;
 
-    LOW_ALARM = 48223590;
+    LOW_ALARM = 316659046;
 
-    LOW_WARNING = 70358385;
+    LOW_WARNING = 338793841;
 
     OK = 2524;
 
@@ -7102,7 +7102,7 @@ message InterconnectList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -7116,18 +7116,18 @@ message InterconnectLocationRegionInfo {
     // A value indicating that the enum field is not set.
     UNDEFINED_LOCATION_PRESENCE = 0;
 
-    GLOBAL = 226228131;
+    GLOBAL = 494663587;
 
-    LOCAL_REGION = 135100008;
+    LOCAL_REGION = 403535464;
 
-    LP_GLOBAL = 161148606;
+    LP_GLOBAL = 429584062;
 
-    LP_LOCAL_REGION = 220163395;
+    LP_LOCAL_REGION = 488598851;
 
   }
 
   // Expected round-trip time in milliseconds, from this InterconnectLocation to a VM in this region.
-  optional string expected_rtt_ms = 154108410;
+  optional string expected_rtt_ms = 422543866;
 
   // Identifies the network presence of this location.
   optional LocationPresence location_presence = 101517893;
@@ -7151,23 +7151,23 @@ message InterconnectLocation {
     // A value indicating that the enum field is not set.
     UNDEFINED_CONTINENT = 0;
 
-    AFRICA = 49008250;
+    AFRICA = 317443706;
 
     ASIA_PAC = 119782269;
 
     C_AFRICA = 71993846;
 
-    C_ASIA_PAC = 197232633;
+    C_ASIA_PAC = 465668089;
 
     C_EUROPE = 200369438;
 
-    C_NORTH_AMERICA = 7261592;
+    C_NORTH_AMERICA = 275697048;
 
-    C_SOUTH_AMERICA = 128714336;
+    C_SOUTH_AMERICA = 397149792;
 
-    EUROPE = 177383842;
+    EUROPE = 445819298;
 
-    NORTH_AMERICA = 179580052;
+    NORTH_AMERICA = 448015508;
 
     SOUTH_AMERICA = 32597340;
 
@@ -7180,14 +7180,14 @@ message InterconnectLocation {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    AVAILABLE = 173644457;
+    AVAILABLE = 442079913;
 
-    CLOSED = 111727980;
+    CLOSED = 380163436;
 
   }
 
   // [Output Only] The postal address of the Point of Presence, each line in the address is separated by a newline character.
-  optional string address = 194485236;
+  optional string address = 462920692;
 
   // [Output Only] Availability zone for this InterconnectLocation. Within a metropolitan area (metro), maintenance will not be simultaneously scheduled in more than one availability zone. Example: "zone1" or "zone2".
   optional string availability_zone = 158459920;
@@ -7207,10 +7207,10 @@ message InterconnectLocation {
   optional string creation_timestamp = 30525366;
 
   // [Output Only] An optional description of the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The name of the provider for this facility (e.g., EQUINIX).
-  optional string facility_provider = 264867853;
+  optional string facility_provider = 533303309;
 
   // [Output Only] A provider-assigned Identifier for this facility (e.g., Ashburn-DC1).
   optional string facility_provider_facility_id = 87269125;
@@ -7225,13 +7225,13 @@ message InterconnectLocation {
   optional string name = 3373707;
 
   // [Output Only] The peeringdb identifier for this facility (corresponding with a netfac type in peeringdb).
-  optional string peeringdb_facility_id = 268131638;
+  optional string peeringdb_facility_id = 536567094;
 
   // [Output Only] A list of InterconnectLocation.RegionInfo objects, that describe parameters pertaining to the relation between this InterconnectLocation and various Google Cloud regions.
-  repeated InterconnectLocationRegionInfo region_infos = 43758714;
+  repeated InterconnectLocationRegionInfo region_infos = 312194170;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The status of this InterconnectLocation, which can take one of the following values:
   // - CLOSED: The InterconnectLocation is closed and is unavailable for provisioning new Interconnects.
@@ -7255,7 +7255,7 @@ message InterconnectLocationList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -7271,10 +7271,10 @@ message InterconnectsGetDiagnosticsResponse {
 //
 message LicenseResourceRequirements {
   // Minimum number of guest cpus required to use the Instance. Enforced at Instance creation and Instance start.
-  optional int32 min_guest_cpu_count = 209529380;
+  optional int32 min_guest_cpu_count = 477964836;
 
   // Minimum memory required to use the Instance. Enforced at Instance creation and Instance start.
-  optional int32 min_memory_mb = 236350438;
+  optional int32 min_memory_mb = 504785894;
 
 }
 
@@ -7283,13 +7283,13 @@ message LicenseResourceRequirements {
 // A License represents billing and aggregate usage data for public and marketplace images.  Caution This resource is intended for use only by third-party partners who are creating Cloud Marketplace images. (== resource_for {$api_version}.licenses ==)
 message License {
   // [Output Only] Deprecated. This field no longer reflects whether a license charges a usage fee.
-  optional bool charges_use_fee = 103977166;
+  optional bool charges_use_fee = 372412622;
 
   // [Output Only] Creation timestamp in RFC3339 text format.
   optional string creation_timestamp = 30525366;
 
   // An optional textual description of the resource; provided by the client when the resource is created.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -7306,7 +7306,7 @@ message License {
   optional LicenseResourceRequirements resource_requirements = 214292769;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // If false, licenses will not be copied from the source resource when creating an image from a disk, disk from snapshot, or snapshot from disk.
   optional bool transferable = 4349893;
@@ -7316,10 +7316,10 @@ message License {
 //
 message LicenseCodeLicenseAlias {
   // [Output Only] Description of this License Code.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] URL of license corresponding to this License Code.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
 }
 
@@ -7332,13 +7332,13 @@ message LicenseCode {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATE = 0;
 
-    DISABLED = 248261244;
+    DISABLED = 516696700;
 
     ENABLED = 182130465;
 
     RESTRICTED = 261551195;
 
-    STATE_UNSPECIFIED = 202319945;
+    STATE_UNSPECIFIED = 470755401;
 
     TERMINATED = 250018339;
 
@@ -7348,7 +7348,7 @@ message LicenseCode {
   optional string creation_timestamp = 30525366;
 
   // [Output Only] Description of this License Code.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -7363,7 +7363,7 @@ message LicenseCode {
   optional string name = 3373707;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Current state of this License Code.
   optional State state = 109757585;
@@ -7385,7 +7385,7 @@ message LicensesListResponse {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -7398,7 +7398,7 @@ message LocalDisk {
   optional int32 disk_count = 182933485;
 
   // Specifies the size of the disk in base-2 GB.
-  optional int32 disk_size_gb = 47828279;
+  optional int32 disk_size_gb = 316263735;
 
   // Specifies the desired disk type on the node. This disk type must be a local storage type (e.g.: local-ssd). Note that for nodeTemplates, this should be the name of the disk type and not its URL.
   optional string disk_type = 93009052;
@@ -7412,11 +7412,11 @@ message LogConfigCloudAuditOptions {
     // A value indicating that the enum field is not set.
     UNDEFINED_LOG_NAME = 0;
 
-    ADMIN_ACTIVITY = 159067679;
+    ADMIN_ACTIVITY = 427503135;
 
     DATA_ACCESS = 238070681;
 
-    UNSPECIFIED_LOG_NAME = 142079726;
+    UNSPECIFIED_LOG_NAME = 410515182;
 
   }
 
@@ -7424,7 +7424,7 @@ message LogConfigCloudAuditOptions {
   optional AuthorizationLoggingOptions authorization_logging_options = 217861624;
 
   // The log_name to populate in the Cloud Audit Record.
-  optional LogName log_name = 134478502;
+  optional LogName log_name = 402913958;
 
 }
 
@@ -7445,7 +7445,7 @@ message LogConfigCounterOptions {
   optional string field = 97427706;
 
   // The metric to update.
-  optional string metric = 264631728;
+  optional string metric = 533067184;
 
 }
 
@@ -7456,26 +7456,26 @@ message LogConfigDataAccessOptions {
     // A value indicating that the enum field is not set.
     UNDEFINED_LOG_MODE = 0;
 
-    LOG_FAIL_CLOSED = 92034322;
+    LOG_FAIL_CLOSED = 360469778;
 
     LOG_MODE_UNSPECIFIED = 88160822;
 
   }
 
-  optional LogMode log_mode = 134461886;
+  optional LogMode log_mode = 402897342;
 
 }
 
 // Specifies what kind of log the caller must write
 message LogConfig {
   // Cloud audit options.
-  optional LogConfigCloudAuditOptions cloud_audit = 144417105;
+  optional LogConfigCloudAuditOptions cloud_audit = 412852561;
 
   // Counter options.
-  optional LogConfigCounterOptions counter = 152524284;
+  optional LogConfigCounterOptions counter = 420959740;
 
   // Data access options.
-  optional LogConfigDataAccessOptions data_access = 18198425;
+  optional LogConfigDataAccessOptions data_access = 286633881;
 
 }
 
@@ -7492,10 +7492,10 @@ message LogConfigCounterOptionsCustomField {
 //
 message Accelerators {
   // Number of accelerator cards exposed to the guest.
-  optional int32 guest_accelerator_count = 210643860;
+  optional int32 guest_accelerator_count = 479079316;
 
   // The accelerator type resource name, not a full URL, e.g. 'nvidia-tesla-k80'.
-  optional string guest_accelerator_type = 24629269;
+  optional string guest_accelerator_type = 293064725;
 
 }
 
@@ -7511,19 +7511,19 @@ message ScratchDisks {
 // You can use specific machine types for your VM instances based on performance and pricing requirements. For more information, read Machine Types. (== resource_for {$api_version}.machineTypes ==)
 message MachineType {
   // [Output Only] A list of accelerator configurations assigned to this machine type.
-  repeated Accelerators accelerators = 1141608;
+  repeated Accelerators accelerators = 269577064;
 
   // [Output Only] Creation timestamp in RFC3339 text format.
   optional string creation_timestamp = 30525366;
 
   // [Output Only] The deprecation status associated with this machine type. Only applicable if the machine type is unavailable.
-  optional DeprecationStatus deprecated = 246703539;
+  optional DeprecationStatus deprecated = 515138995;
 
   // [Output Only] An optional textual description of the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The number of virtual CPUs that are available to the instance.
-  optional int32 guest_cpus = 124921298;
+  optional int32 guest_cpus = 393356754;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -7532,13 +7532,13 @@ message MachineType {
   optional int32 image_space_gb = 75331864;
 
   // [Output Only] Whether this machine type has a shared CPU. See Shared-core machine types for more information.
-  optional bool is_shared_cpu = 252964099;
+  optional bool is_shared_cpu = 521399555;
 
   // [Output Only] The type of the resource. Always compute#machineType for machine types.
   optional string kind = 3292052;
 
   // [Output Only] Maximum persistent disks allowed.
-  optional int32 maximum_persistent_disks = 227785485;
+  optional int32 maximum_persistent_disks = 496220941;
 
   // [Output Only] Maximum total persistent disks size (GB) allowed.
   optional string maximum_persistent_disks_size_gb = 154274471;
@@ -7550,10 +7550,10 @@ message MachineType {
   optional string name = 3373707;
 
   // [Output Only] A list of extended scratch disks assigned to the instance.
-  repeated ScratchDisks scratch_disks = 212343025;
+  repeated ScratchDisks scratch_disks = 480778481;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The name of the zone where the machine type resides, such as us-central1-a.
   optional string zone = 3744684;
@@ -7585,7 +7585,7 @@ message MachineTypeAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -7610,7 +7610,7 @@ message MachineTypeList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -7624,30 +7624,30 @@ message ManagedInstanceInstanceHealth {
     // A value indicating that the enum field is not set.
     UNDEFINED_DETAILED_HEALTH_STATE = 0;
 
-    DRAINING = 212019946;
+    DRAINING = 480455402;
 
-    HEALTHY = 171365757;
+    HEALTHY = 439801213;
 
-    TIMEOUT = 209377601;
+    TIMEOUT = 477813057;
 
-    UNHEALTHY = 193682628;
+    UNHEALTHY = 462118084;
 
-    UNKNOWN = 164706346;
+    UNKNOWN = 433141802;
 
   }
 
   // [Output Only] The current detailed instance health state.
-  optional DetailedHealthState detailed_health_state = 242034717;
+  optional DetailedHealthState detailed_health_state = 510470173;
 
   // [Output Only] The URL for the health check that verifies whether the instance is healthy.
-  optional string health_check = 40441189;
+  optional string health_check = 308876645;
 
 }
 
 //
 message ManagedInstanceLastAttempt {
   // [Output Only] Encountered errors during the last attempt to create or delete the instance.
-  optional Errors errors = 47542123;
+  optional Errors errors = 315977579;
 
 }
 
@@ -7667,10 +7667,10 @@ message Errors {
   optional string code = 3059181;
 
   // [Output Only] Indicates the field in the request that caused the error. This property is optional.
-  optional string location = 21995445;
+  optional string location = 290430901;
 
   // [Output Only] An optional, human-readable error message.
-  optional string message = 149618695;
+  optional string message = 418054151;
 
 }
 
@@ -7703,9 +7703,9 @@ message NetworkPeering {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATE = 0;
 
-    ACTIVE = 46297862;
+    ACTIVE = 314733318;
 
-    INACTIVE = 1985643;
+    INACTIVE = 270421099;
 
   }
 
@@ -7751,14 +7751,14 @@ message NetworkRoutingConfig {
     // A value indicating that the enum field is not set.
     UNDEFINED_ROUTING_MODE = 0;
 
-    GLOBAL = 226228131;
+    GLOBAL = 494663587;
 
     REGIONAL = 92288543;
 
   }
 
   // The network-wide routing mode to use. If set to REGIONAL, this network's Cloud Routers will only advertise routes with subnets of this network in the same region as the router. If set to GLOBAL, this network's Cloud Routers will advertise routes with all subnets of this network, across regions.
-  optional RoutingMode routing_mode = 206708092;
+  optional RoutingMode routing_mode = 475143548;
 
 }
 
@@ -7779,7 +7779,7 @@ message Network {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this field when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The gateway address for default routing out of the network, selected by GCP.
   optional string gateway_i_pv4 = 178678877;
@@ -7803,13 +7803,13 @@ message Network {
   repeated NetworkPeering peerings = 69883187;
 
   // The network-level routing configuration for this network. Used by Cloud Router to determine what type of network-wide routing behavior to enforce.
-  optional NetworkRoutingConfig routing_config = 255120603;
+  optional NetworkRoutingConfig routing_config = 523556059;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Server-defined fully-qualified URLs for all subnetworks in this VPC network.
-  repeated string subnetworks = 147417669;
+  repeated string subnetworks = 415853125;
 
 }
 
@@ -7822,7 +7822,7 @@ message NetworkEndpointGroupAppEngine {
   // The service name is case-sensitive and must be 1-63 characters long.
   //
   // Example value: "default", "my-service".
-  optional string service = 105105077;
+  optional string service = 373540533;
 
   // A template to parse service and version fields from a request URL. URL mask allows for routing to multiple App Engine services without having to create multiple Network Endpoint Groups and backend services.
   //
@@ -7834,7 +7834,7 @@ message NetworkEndpointGroupAppEngine {
   // The version name is case-sensitive and must be 1-100 characters long.
   //
   // Example value: "v1", "v2".
-  optional string version = 83172568;
+  optional string version = 351608024;
 
 }
 
@@ -7847,7 +7847,7 @@ message NetworkEndpointGroupCloudFunction {
   // The function name is case-sensitive and must be 1-63 characters long.
   //
   // Example value: "func1".
-  optional string function = 38761432;
+  optional string function = 307196888;
 
   // A template to parse function field from a request URL. URL mask allows for routing to multiple Cloud Functions without having to create multiple Network Endpoint Groups and backend services.
   //
@@ -7865,7 +7865,7 @@ message NetworkEndpointGroupCloudRun {
   // The service must be 1-63 characters long, and comply with RFC1035.
   //
   // Example value: "run-service".
-  optional string service = 105105077;
+  optional string service = 373540533;
 
   // Optional Cloud Run tag represents the "named-revision" to provide additional fine-grained traffic routing information.
   //
@@ -7890,15 +7890,15 @@ message NetworkEndpointGroup {
     // A value indicating that the enum field is not set.
     UNDEFINED_NETWORK_ENDPOINT_TYPE = 0;
 
-    GCE_VM_IP_PORT = 233402919;
+    GCE_VM_IP_PORT = 501838375;
 
-    INTERNET_FQDN_PORT = 135719021;
+    INTERNET_FQDN_PORT = 404154477;
 
-    INTERNET_IP_PORT = 209284507;
+    INTERNET_IP_PORT = 477719963;
 
-    NON_GCP_PRIVATE_IP_PORT = 68012512;
+    NON_GCP_PRIVATE_IP_PORT = 336447968;
 
-    SERVERLESS = 2057052;
+    SERVERLESS = 270492508;
 
   }
 
@@ -7906,10 +7906,10 @@ message NetworkEndpointGroup {
   map<string, string> annotations = 112032548;
 
   // Only valid when networkEndpointType is "SERVERLESS". Only one of cloudRun, appEngine or cloudFunction may be set.
-  optional NetworkEndpointGroupAppEngine app_engine = 72353312;
+  optional NetworkEndpointGroupAppEngine app_engine = 340788768;
 
   // Only valid when networkEndpointType is "SERVERLESS". Only one of cloudRun, appEngine or cloudFunction may be set.
-  optional NetworkEndpointGroupCloudFunction cloud_function = 251458210;
+  optional NetworkEndpointGroupCloudFunction cloud_function = 519893666;
 
   // Only valid when networkEndpointType is "SERVERLESS". Only one of cloudRun, appEngine or cloudFunction may be set.
   optional NetworkEndpointGroupCloudRun cloud_run = 111060353;
@@ -7918,10 +7918,10 @@ message NetworkEndpointGroup {
   optional string creation_timestamp = 30525366;
 
   // The default port used if the port number is not specified in the network endpoint.
-  optional int32 default_port = 154942399;
+  optional int32 default_port = 423377855;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -7942,13 +7942,13 @@ message NetworkEndpointGroup {
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output only] Number of network endpoints in the network endpoint group.
   optional int32 size = 3530753;
 
   // Optional URL of the subnetwork to which all network endpoints in the NEG belong.
-  optional string subnetwork = 39392238;
+  optional string subnetwork = 307827694;
 
   // [Output Only] The URL of the zone where the network endpoint group is located.
   optional string zone = 3744684;
@@ -7980,7 +7980,7 @@ message NetworkEndpointGroupAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -8005,7 +8005,7 @@ message NetworkEndpointGroupList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -8040,7 +8040,7 @@ message NetworkEndpointGroupsListEndpointsRequest {
   }
 
   // Optional query parameter for showing the health status of each network endpoint. Valid options are SKIP or SHOW. If you don't specify this parameter, the health status of network endpoints will not be provided.
-  optional HealthStatus health_status = 112110389;
+  optional HealthStatus health_status = 380545845;
 
 }
 
@@ -8088,7 +8088,7 @@ message NetworkList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -8104,10 +8104,10 @@ message NetworksAddPeeringRequest {
   optional string name = 3373707;
 
   // Network peering parameters. In order to specify route policies for peering using import and export custom routes, you must specify all peering related parameters (name, peer network, exchange_subnet_routes) in the network_peering field. The corresponding fields in NetworksAddPeeringRequest will be deprecated soon.
-  optional NetworkPeering network_peering = 60491311;
+  optional NetworkPeering network_peering = 328926767;
 
   // URL of the peer network. It can be either full URL or partial URL. The peer network may belong to a different project. If the partial URL does not contain project, it is assumed that the peer network is in the same project as the current network.
-  optional string peer_network = 232190033;
+  optional string peer_network = 500625489;
 
 }
 
@@ -8120,7 +8120,7 @@ message NetworksRemovePeeringRequest {
 
 //
 message NetworksUpdatePeeringRequest {
-  optional NetworkPeering network_peering = 60491311;
+  optional NetworkPeering network_peering = 328926767;
 
 }
 
@@ -8131,7 +8131,7 @@ message NodeGroupAutoscalingPolicy {
     // A value indicating that the enum field is not set.
     UNDEFINED_MODE = 0;
 
-    MODE_UNSPECIFIED = 102912635;
+    MODE_UNSPECIFIED = 371348091;
 
     OFF = 78159;
 
@@ -8142,10 +8142,10 @@ message NodeGroupAutoscalingPolicy {
   }
 
   // The maximum number of nodes that the group should have. Must be set if autoscaling is enabled. Maximum value allowed is 100.
-  optional int32 max_nodes = 29327382;
+  optional int32 max_nodes = 297762838;
 
   // The minimum number of nodes that the group should have.
-  optional int32 min_nodes = 264935044;
+  optional int32 min_nodes = 533370500;
 
   // The autoscaling mode. Set to one of: ON, OFF, or ONLY_SCALE_OUT. For more information, see  Autoscaler modes.
   optional Mode mode = 3357091;
@@ -8155,7 +8155,7 @@ message NodeGroupAutoscalingPolicy {
 // Time window specified for daily maintenance operations. GCE's internal maintenance will be performed within this window.
 message NodeGroupMaintenanceWindow {
   // [Output only] A predetermined duration for the window, automatically chosen to be the smallest possible in the given scenario.
-  optional Duration maintenance_duration = 256856384;
+  optional Duration maintenance_duration = 525291840;
 
   // Start time of the window. This must be in UTC format that resolves to one of 00:00, 04:00, 08:00, 12:00, 16:00, or 20:00. For example, both 13:00-5 and 08:00 are valid.
   optional string start_time = 37467274;
@@ -8186,11 +8186,11 @@ message NodeGroup {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    CREATING = 187129529;
+    CREATING = 455564985;
 
-    DELETING = 260166568;
+    DELETING = 528602024;
 
-    INVALID = 261848535;
+    INVALID = 530283991;
 
     READY = 77848963;
 
@@ -8203,7 +8203,7 @@ message NodeGroup {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   optional string fingerprint = 234678500;
 
@@ -8214,7 +8214,7 @@ message NodeGroup {
   optional string kind = 3292052;
 
   // Specifies how to handle instances when a node in the group undergoes maintenance. Set to one of: DEFAULT, RESTART_IN_PLACE, or MIGRATE_WITHIN_NODE_GROUP. The default value is DEFAULT. For more information, see  Maintenance policies.
-  optional MaintenancePolicy maintenance_policy = 259892190;
+  optional MaintenancePolicy maintenance_policy = 528327646;
 
   optional NodeGroupMaintenanceWindow maintenance_window = 186374812;
 
@@ -8222,10 +8222,10 @@ message NodeGroup {
   optional string name = 3373707;
 
   // URL of the node template to create the node group from.
-  optional string node_template = 54718999;
+  optional string node_template = 323154455;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The total number of nodes in the node group.
   optional int32 size = 3530753;
@@ -8262,7 +8262,7 @@ message NodeGroupAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -8287,7 +8287,7 @@ message NodeGroupList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -8301,7 +8301,7 @@ message ServerBinding {
     // A value indicating that the enum field is not set.
     UNDEFINED_TYPE = 0;
 
-    RESTART_NODE_ON_ANY_SERVER = 234515529;
+    RESTART_NODE_ON_ANY_SERVER = 502950985;
 
     RESTART_NODE_ON_MINIMAL_SERVERS = 204166495;
 
@@ -8320,7 +8320,7 @@ message NodeGroupNode {
     // A value indicating that the enum field is not set.
     UNDEFINED_CPU_OVERCOMMIT_TYPE = 0;
 
-    CPU_OVERCOMMIT_TYPE_UNSPECIFIED = 252230159;
+    CPU_OVERCOMMIT_TYPE_UNSPECIFIED = 520665615;
 
     ENABLED = 182130465;
 
@@ -8333,20 +8333,20 @@ message NodeGroupNode {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    CREATING = 187129529;
+    CREATING = 455564985;
 
-    DELETING = 260166568;
+    DELETING = 528602024;
 
-    INVALID = 261848535;
+    INVALID = 530283991;
 
     READY = 77848963;
 
-    REPAIRING = 145047829;
+    REPAIRING = 413483285;
 
   }
 
   // Accelerators for this node.
-  repeated AcceleratorConfig accelerators = 1141608;
+  repeated AcceleratorConfig accelerators = 269577064;
 
   // CPU overcommit.
   optional CpuOvercommitType cpu_overcommit_type = 247727959;
@@ -8361,13 +8361,13 @@ message NodeGroupNode {
   optional string name = 3373707;
 
   // The type of this node.
-  optional string node_type = 197397335;
+  optional string node_type = 465832791;
 
   // Binding properties for the physical server.
   optional ServerBinding server_binding = 208179593;
 
   // Server ID associated with this node.
-  optional string server_id = 70997911;
+  optional string server_id = 339433367;
 
   optional Status status = 181260274;
 
@@ -8402,7 +8402,7 @@ message NodeGroupsListNodes {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -8412,7 +8412,7 @@ message NodeGroupsListNodes {
 //
 message NodeGroupsSetNodeTemplateRequest {
   // Full or partial URL of the node template resource to be updated for this node group.
-  optional string node_template = 54718999;
+  optional string node_template = 323154455;
 
 }
 
@@ -8420,9 +8420,9 @@ message NodeGroupsSetNodeTemplateRequest {
 message NodeTemplateNodeTypeFlexibility {
   optional string cpus = 3060683;
 
-  optional string local_ssd = 137305904;
+  optional string local_ssd = 405741360;
 
-  optional string memory = 264420609;
+  optional string memory = 532856065;
 
 }
 
@@ -8435,7 +8435,7 @@ message NodeTemplate {
     // A value indicating that the enum field is not set.
     UNDEFINED_CPU_OVERCOMMIT_TYPE = 0;
 
-    CPU_OVERCOMMIT_TYPE_UNSPECIFIED = 252230159;
+    CPU_OVERCOMMIT_TYPE_UNSPECIFIED = 520665615;
 
     ENABLED = 182130465;
 
@@ -8448,17 +8448,17 @@ message NodeTemplate {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    CREATING = 187129529;
+    CREATING = 455564985;
 
-    DELETING = 260166568;
+    DELETING = 528602024;
 
-    INVALID = 261848535;
+    INVALID = 530283991;
 
     READY = 77848963;
 
   }
 
-  repeated AcceleratorConfig accelerators = 1141608;
+  repeated AcceleratorConfig accelerators = 269577064;
 
   // CPU overcommit.
   optional CpuOvercommitType cpu_overcommit_type = 247727959;
@@ -8467,7 +8467,7 @@ message NodeTemplate {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   repeated LocalDisk disks = 95594102;
 
@@ -8481,21 +8481,21 @@ message NodeTemplate {
   optional string name = 3373707;
 
   // Labels to use for node affinity, which will be used in instance scheduling.
-  map<string, string> node_affinity_labels = 70571705;
+  map<string, string> node_affinity_labels = 339007161;
 
   // The node type to use for nodes group that are created from this template.
-  optional string node_type = 197397335;
+  optional string node_type = 465832791;
 
   // The flexible properties of the desired node type. Node groups that use this node template will create nodes of a type that matches these properties.
   //
   // This field is mutually exclusive with the node_type property; you can only define one or the other, but not both.
-  optional NodeTemplateNodeTypeFlexibility node_type_flexibility = 46822449;
+  optional NodeTemplateNodeTypeFlexibility node_type_flexibility = 315257905;
 
   // [Output Only] The name of the region where the node template resides, such as us-central1.
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // Sets the binding properties for the physical server. Valid values include:
   // - [Default] RESTART_NODE_ON_ANY_SERVER: Restarts VMs on any available physical server
@@ -8508,14 +8508,14 @@ message NodeTemplate {
   optional Status status = 181260274;
 
   // [Output Only] An optional, human-readable explanation of the status.
-  optional string status_message = 28992698;
+  optional string status_message = 297428154;
 
 }
 
 //
 message NodeTemplatesScopedList {
   // [Output Only] A list of node templates contained in this scope.
-  repeated NodeTemplate node_templates = 85676348;
+  repeated NodeTemplate node_templates = 354111804;
 
   // [Output Only] An informational warning that appears when the node templates list is empty.
   optional Warning warning = 50704284;
@@ -8537,7 +8537,7 @@ message NodeTemplateAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -8562,7 +8562,7 @@ message NodeTemplateList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -8574,19 +8574,19 @@ message NodeTemplateList {
 // Each node within a node group must have a node type. A node type specifies the total amount of cores and memory for that node. Currently, the only available node type is n1-node-96-624 node type that has 96 vCPUs and 624 GB of memory, available in multiple zones. For more information read Node types. (== resource_for {$api_version}.nodeTypes ==)
 message NodeType {
   // [Output Only] The CPU platform used by this node type.
-  optional string cpu_platform = 141849898;
+  optional string cpu_platform = 410285354;
 
   // [Output Only] Creation timestamp in RFC3339 text format.
   optional string creation_timestamp = 30525366;
 
   // [Output Only] The deprecation status associated with this node type.
-  optional DeprecationStatus deprecated = 246703539;
+  optional DeprecationStatus deprecated = 515138995;
 
   // [Output Only] An optional textual description of the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The number of virtual CPUs that are available to the node type.
-  optional int32 guest_cpus = 124921298;
+  optional int32 guest_cpus = 393356754;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -8595,7 +8595,7 @@ message NodeType {
   optional string kind = 3292052;
 
   // [Output Only] Local SSD available to the node type, defined in GB.
-  optional int32 local_ssd_gb = 60802122;
+  optional int32 local_ssd_gb = 329237578;
 
   // [Output Only] The amount of physical memory available to the node type, defined in MB.
   optional int32 memory_mb = 116001171;
@@ -8604,7 +8604,7 @@ message NodeType {
   optional string name = 3373707;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The name of the zone where the node type resides, such as us-central1-a.
   optional string zone = 3744684;
@@ -8614,7 +8614,7 @@ message NodeType {
 //
 message NodeTypesScopedList {
   // [Output Only] A list of node types contained in this scope.
-  repeated NodeType node_types = 213737468;
+  repeated NodeType node_types = 482172924;
 
   // [Output Only] An informational warning that appears when the node types list is empty.
   optional Warning warning = 50704284;
@@ -8636,7 +8636,7 @@ message NodeTypeAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -8661,7 +8661,7 @@ message NodeTypeList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -8671,16 +8671,16 @@ message NodeTypeList {
 // Represents a gRPC setting that describes one gRPC notification endpoint and the retry duration attempting to send notification to this endpoint.
 message NotificationEndpointGrpcSettings {
   // Optional. If specified, this field is used to set the authority header by the sender of notifications. See https://tools.ietf.org/html/rfc7540#section-8.1.2.3
-  optional string authority = 133433155;
+  optional string authority = 401868611;
 
   // Endpoint to which gRPC notifications are sent. This must be a valid gRPCLB DNS name.
   optional string endpoint = 130489749;
 
   // Optional. If specified, this field is used to populate the "name" field in gRPC requests.
-  optional string payload_name = 31922844;
+  optional string payload_name = 300358300;
 
   // Optional. This field is used to configure how often to send a full update of all non-healthy backends. If unspecified, full updates are not sent. If specified, must be in the range between 600 seconds to 3600 seconds. Nanos are disallowed.
-  optional Duration resend_interval = 209853513;
+  optional Duration resend_interval = 478288969;
 
   // How much time (in seconds) is spent attempting notification retries until a successful response is received. Default is 30s. Limit is 20m (1200s). Must be a positive number.
   optional uint32 retry_duration_sec = 115681117;
@@ -8697,10 +8697,10 @@ message NotificationEndpoint {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Settings of the gRPC notification endpoint including the endpoint URL and the retry duration.
-  optional NotificationEndpointGrpcSettings grpc_settings = 187704100;
+  optional NotificationEndpointGrpcSettings grpc_settings = 456139556;
 
   // [Output Only] A unique identifier for this resource type. The server generates this identifier.
   optional string id = 3355;
@@ -8715,7 +8715,7 @@ message NotificationEndpoint {
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
 }
 
@@ -8734,7 +8734,7 @@ message NotificationEndpointList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -8744,7 +8744,7 @@ message NotificationEndpointList {
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
 message Error {
   // [Output Only] The array of errors encountered while processing this operation.
-  repeated Errors errors = 47542123;
+  repeated Errors errors = 315977579;
 
 }
 
@@ -8757,33 +8757,33 @@ message Warnings {
 
     CLEANUP_FAILED = 150308440;
 
-    DEPRECATED_RESOURCE_USED = 123400130;
+    DEPRECATED_RESOURCE_USED = 391835586;
 
-    DEPRECATED_TYPE_USED = 78090774;
+    DEPRECATED_TYPE_USED = 346526230;
 
-    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 101007511;
+    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 369442967;
 
-    EXPERIMENTAL_TYPE_USED = 183518987;
+    EXPERIMENTAL_TYPE_USED = 451954443;
 
     EXTERNAL_API_WARNING = 175546307;
 
-    FIELD_VALUE_OVERRIDEN = 61233967;
+    FIELD_VALUE_OVERRIDEN = 329669423;
 
-    INJECTED_KERNELS_DEPRECATED = 148941963;
+    INJECTED_KERNELS_DEPRECATED = 417377419;
 
-    LARGE_DEPLOYMENT_WARNING = 213005222;
+    LARGE_DEPLOYMENT_WARNING = 481440678;
 
-    MISSING_TYPE_DEPENDENCY = 76070007;
+    MISSING_TYPE_DEPENDENCY = 344505463;
 
-    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 56529543;
+    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 324964999;
 
-    NEXT_HOP_CANNOT_IP_FORWARD = 114947431;
+    NEXT_HOP_CANNOT_IP_FORWARD = 383382887;
 
-    NEXT_HOP_INSTANCE_NOT_FOUND = 195814990;
+    NEXT_HOP_INSTANCE_NOT_FOUND = 464250446;
 
     NEXT_HOP_INSTANCE_NOT_ON_NETWORK = 243758146;
 
-    NEXT_HOP_NOT_RUNNING = 148645809;
+    NEXT_HOP_NOT_RUNNING = 417081265;
 
     NOT_CRITICAL_ERROR = 105763924;
 
@@ -8793,15 +8793,15 @@ message Warnings {
 
     REQUIRED_TOS_AGREEMENT = 3745539;
 
-    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 228293185;
+    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 496728641;
 
     RESOURCE_NOT_DELETED = 168598460;
 
-    SCHEMA_VALIDATION_IGNORED = 6810186;
+    SCHEMA_VALIDATION_IGNORED = 275245642;
 
     SINGLE_INSTANCE_PROPERTY_TEMPLATE = 268305617;
 
-    UNDECLARED_PROPERTIES = 122077983;
+    UNDECLARED_PROPERTIES = 390513439;
 
     UNREACHABLE = 13328052;
 
@@ -8815,7 +8815,7 @@ message Warnings {
   repeated Data data = 3076010;
 
   // [Output Only] A human-readable description of the warning code.
-  optional string message = 149618695;
+  optional string message = 418054151;
 
 }
 
@@ -8848,13 +8848,13 @@ message Operation {
   }
 
   // [Output Only] The value of `requestId` if you provided it in the request. Not present otherwise.
-  optional string client_operation_id = 28804839;
+  optional string client_operation_id = 297240295;
 
   // [Deprecated] This field is deprecated.
   optional string creation_timestamp = 30525366;
 
   // [Output Only] A textual description of the operation, which is set when the operation is created.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
   optional string end_time = 114938801;
@@ -8866,13 +8866,13 @@ message Operation {
   optional string http_error_message = 202521945;
 
   // [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a `404` means the resource was not found.
-  optional int32 http_error_status_code = 43909740;
+  optional int32 http_error_status_code = 312345196;
 
   // [Output Only] The unique identifier for the operation. This identifier is defined by the server.
   optional string id = 3355;
 
   // [Output Only] The time that this operation was requested. This value is in RFC3339 text format.
-  optional string insert_time = 165287059;
+  optional string insert_time = 433722515;
 
   // [Output Only] Type of the resource. Always `compute#operation` for Operation resources.
   optional string kind = 3292052;
@@ -8890,7 +8890,7 @@ message Operation {
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The time that this operation was started by the server. This value is in RFC3339 text format.
   optional string start_time = 37467274;
@@ -8899,7 +8899,7 @@ message Operation {
   optional Status status = 181260274;
 
   // [Output Only] An optional textual description of the current status of the operation.
-  optional string status_message = 28992698;
+  optional string status_message = 297428154;
 
   // [Output Only] The unique target ID, which identifies a specific incarnation of the target resource.
   optional string target_id = 258165385;
@@ -8911,7 +8911,7 @@ message Operation {
   optional string user = 3599307;
 
   // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-  repeated Warnings warnings = 229655639;
+  repeated Warnings warnings = 498091095;
 
   // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
   optional string zone = 3744684;
@@ -8943,7 +8943,7 @@ message OperationAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -8968,7 +8968,7 @@ message OperationList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -8978,7 +8978,7 @@ message OperationList {
 //
 message PacketMirroringForwardingRuleInfo {
   // [Output Only] Unique identifier for the forwarding rule; defined by the server.
-  optional string canonical_url = 243859364;
+  optional string canonical_url = 512294820;
 
   // Resource URL to the forwarding rule representing the ILB configured as destination of the mirrored traffic.
   optional string url = 116079;
@@ -8994,20 +8994,20 @@ message PacketMirroringFilter {
 
     BOTH = 2044801;
 
-    EGRESS = 164445045;
+    EGRESS = 432880501;
 
-    INGRESS = 248495765;
+    INGRESS = 516931221;
 
   }
 
   // IP CIDR ranges that apply as filter on the source (ingress) or destination (egress) IP in the IP header. Only IPv4 is supported. If no ranges are specified, all traffic that matches the specified IPProtocols is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-  repeated string cidr_ranges = 219466241;
+  repeated string cidr_ranges = 487901697;
 
   // Direction of traffic to mirror, either INGRESS, EGRESS, or BOTH. The default is BOTH.
   optional Direction direction = 111150975;
 
   // Protocols that apply as filter on mirrored traffic. If no protocols are specified, all traffic that matches the specified CIDR ranges is mirrored. If neither cidrRanges nor IPProtocols is specified, all traffic is mirrored.
-  repeated string i_p_protocols = 104889590;
+  repeated string i_p_protocols = 373325046;
 
 }
 
@@ -9023,7 +9023,7 @@ message PacketMirroringMirroredResourceInfo {
   // A set of subnetworks for which traffic from/to all VM instances will be mirrored. They must live in the same region as this packetMirroring.
   //
   // You may specify a maximum of 5 subnetworks.
-  repeated PacketMirroringMirroredResourceInfoSubnetInfo subnetworks = 147417669;
+  repeated PacketMirroringMirroredResourceInfoSubnetInfo subnetworks = 415853125;
 
   // A set of mirrored tags. Traffic from/to all VM instances that have one or more of these tags will be mirrored.
   repeated string tags = 3552281;
@@ -9033,7 +9033,7 @@ message PacketMirroringMirroredResourceInfo {
 //
 message PacketMirroringNetworkInfo {
   // [Output Only] Unique identifier for the network; defined by the server.
-  optional string canonical_url = 243859364;
+  optional string canonical_url = 512294820;
 
   // URL of the network resource.
   optional string url = 116079;
@@ -9058,21 +9058,21 @@ message PacketMirroring {
   }
 
   // The Forwarding Rule resource of type loadBalancingScheme=INTERNAL that will be used as collector for mirrored traffic. The specified forwarding rule must have isMirroringCollector set to true.
-  optional PacketMirroringForwardingRuleInfo collector_ilb = 158172397;
+  optional PacketMirroringForwardingRuleInfo collector_ilb = 426607853;
 
   // [Output Only] Creation timestamp in RFC3339 text format.
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Indicates whether or not this packet mirroring takes effect. If set to FALSE, this packet mirroring policy will not be enforced on the network.
   //
   // The default is TRUE.
-  optional Enable enable = 43328899;
+  optional Enable enable = 311764355;
 
   // Filter for mirrored traffic. If unspecified, all traffic is mirrored.
-  optional PacketMirroringFilter filter = 67685240;
+  optional PacketMirroringFilter filter = 336120696;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -9092,13 +9092,13 @@ message PacketMirroring {
   // The priority of applying this configuration. Priority is used to break ties in cases where there is more than one matching rule. In the case of two rules that apply for a given Instance, the one with the lowest-numbered priority value wins.
   //
   // Default value is 1000. Valid range is 0 through 65535.
-  optional uint32 priority = 176716196;
+  optional uint32 priority = 445151652;
 
   // [Output Only] URI of the region where the packetMirroring resides.
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
 }
 
@@ -9127,7 +9127,7 @@ message PacketMirroringAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -9152,7 +9152,7 @@ message PacketMirroringList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -9162,7 +9162,7 @@ message PacketMirroringList {
 //
 message PacketMirroringMirroredResourceInfoInstanceInfo {
   // [Output Only] Unique identifier for the instance; defined by the server.
-  optional string canonical_url = 243859364;
+  optional string canonical_url = 512294820;
 
   // Resource URL to the virtual machine instance which is being mirrored.
   optional string url = 116079;
@@ -9172,7 +9172,7 @@ message PacketMirroringMirroredResourceInfoInstanceInfo {
 //
 message PacketMirroringMirroredResourceInfoSubnetInfo {
   // [Output Only] Unique identifier for the subnetwork; defined by the server.
-  optional string canonical_url = 243859364;
+  optional string canonical_url = 512294820;
 
   // Resource URL to the subnetwork for which traffic from/to all VM instances will be mirrored.
   optional string url = 116079;
@@ -9187,16 +9187,16 @@ message PathRule {
   // In response to a matching path, the load balancer performs advanced routing actions like URL rewrites, header transformations, etc. prior to forwarding the request to the selected backend. If routeAction specifies any  weightedBackendServices, service must not be set. Conversely if service is set, routeAction cannot contain any  weightedBackendServices.
   // Only one of routeAction or urlRedirect must be set.
   // UrlMaps for external HTTP(S) load balancers support only the urlRewrite action within a pathRule's routeAction.
-  optional HttpRouteAction route_action = 156128492;
+  optional HttpRouteAction route_action = 424563948;
 
   // The full or partial URL of the backend service resource to which traffic is directed if this rule is matched. If routeAction is additionally specified, advanced routing actions like URL Rewrites, etc. take effect prior to sending the request to the backend. However, if service is specified, routeAction cannot contain any weightedBackendService s. Conversely, if routeAction specifies any  weightedBackendServices, service must not be specified.
   // Only one of urlRedirect, service or routeAction.weightedBackendService must be set.
-  optional string service = 105105077;
+  optional string service = 373540533;
 
   // When a path pattern is matched, the request is redirected to a URL specified by urlRedirect.
   // If urlRedirect is specified, service or routeAction must not be set.
   // Not supported when the URL map is bound to target gRPC proxy.
-  optional HttpRedirectAction url_redirect = 136712364;
+  optional HttpRedirectAction url_redirect = 405147820;
 
 }
 
@@ -9205,7 +9205,7 @@ message PathMatcher {
   // defaultRouteAction takes effect when none of the  pathRules or routeRules match. The load balancer performs advanced routing actions like URL rewrites, header transformations, etc. prior to forwarding the request to the selected backend. If defaultRouteAction specifies any weightedBackendServices, defaultService must not be set. Conversely if defaultService is set, defaultRouteAction cannot contain any  weightedBackendServices.
   // Only one of defaultRouteAction or defaultUrlRedirect must be set.
   // UrlMaps for external HTTP(S) load balancers support only the urlRewrite action within a pathMatcher's defaultRouteAction.
-  optional HttpRouteAction default_route_action = 110484010;
+  optional HttpRouteAction default_route_action = 378919466;
 
   // The full or partial URL to the BackendService resource. This will be used if none of the pathRules or routeRules defined by this PathMatcher are matched. For example, the following are all valid URLs to a BackendService resource:
   // - https://www.googleapis.com/compute/v1/projects/project/global/backendServices/backendService
@@ -9215,21 +9215,21 @@ message PathMatcher {
   // Authorization requires one or more of the following Google IAM permissions on the specified resource default_service:
   // - compute.backendBuckets.use
   // - compute.backendServices.use
-  optional string default_service = 101806775;
+  optional string default_service = 370242231;
 
   // When none of the specified pathRules or routeRules match, the request is redirected to a URL specified by defaultUrlRedirect.
   // If defaultUrlRedirect is specified, defaultService or defaultRouteAction must not be set.
   // Not supported when the URL map is bound to target gRPC proxy.
-  optional HttpRedirectAction default_url_redirect = 91067882;
+  optional HttpRedirectAction default_url_redirect = 359503338;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Specifies changes to request and response headers that need to take effect for the selected backendService.
   // HeaderAction specified here are applied after the matching HttpRouteRule HeaderAction and before the HeaderAction in the UrlMap
   // Note that headerAction is not supported for Loadbalancers that have their loadBalancingScheme set to EXTERNAL.
   // Not supported when the URL map is bound to target gRPC proxy that has validateForProxyless field set to true.
-  optional HttpHeaderAction header_action = 59641896;
+  optional HttpHeaderAction header_action = 328077352;
 
   // The name to which this PathMatcher is referred by the HostRule.
   optional string name = 3373707;
@@ -9241,7 +9241,7 @@ message PathMatcher {
 
   // The list of HTTP route rules. Use this list instead of pathRules when advanced route matching and routing actions are desired. routeRules are evaluated in order of priority, from the lowest to highest number.
   // Within a given pathMatcher, you can set only one of pathRules or routeRules.
-  repeated HttpRouteRule route_rules = 107856769;
+  repeated HttpRouteRule route_rules = 376292225;
 
 }
 
@@ -9258,7 +9258,7 @@ message Rule {
 
     DENY = 2094604;
 
-    DENY_WITH_LOG = 82998526;
+    DENY_WITH_LOG = 351433982;
 
     LOG = 75556;
 
@@ -9273,7 +9273,7 @@ message Rule {
   repeated Condition conditions = 142882488;
 
   // Human-readable description of the rule.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // If one or more 'in' clauses are specified, the rule matches if the PRINCIPAL/AUTHORITY_SELECTOR is in at least one of these entries.
   repeated string ins = 104430;
@@ -9282,7 +9282,7 @@ message Rule {
   repeated LogConfig log_configs = 152873846;
 
   // If one or more 'not_in' clauses are specified, the rule matches if the PRINCIPAL/AUTHORITY_SELECTOR is in none of the entries.
-  repeated string not_ins = 250007682;
+  repeated string not_ins = 518443138;
 
   // A permission is a string of form '..' (e.g., 'storage.buckets.list'). A value of '*' matches all permissions, and a verb part of '*' (e.g., 'storage.buckets.*') matches all verbs.
   repeated string permissions = 59962500;
@@ -9305,7 +9305,7 @@ message WafExpressionSet {
 //
 message PreconfiguredWafSet {
   // List of entities that are currently supported for WAF rules.
-  repeated WafExpressionSet expression_sets = 205575576;
+  repeated WafExpressionSet expression_sets = 474011032;
 
 }
 
@@ -9334,7 +9334,7 @@ message PreservedStatePreservedDisk {
   }
 
   // These stateful disks will never be deleted during autohealing, update, instance recreate operations. This flag is used to configure if the disk should be deleted after it is no longer used by the group, e.g. when the given instance or the whole MIG is deleted. Note: disks attached in READ_ONLY mode cannot be auto-deleted.
-  optional AutoDelete auto_delete = 196325947;
+  optional AutoDelete auto_delete = 464761403;
 
   // The mode in which to attach this disk, either READ_WRITE or READ_ONLY. If not specified, the default is to attach the disk in READ_WRITE mode.
   optional Mode mode = 3357091;
@@ -9355,39 +9355,39 @@ message Quota {
 
     AFFINITY_GROUPS = 108303563;
 
-    AUTOSCALERS = 202813532;
+    AUTOSCALERS = 471248988;
 
     BACKEND_BUCKETS = 137626846;
 
-    BACKEND_SERVICES = 1188297;
+    BACKEND_SERVICES = 269623753;
 
-    C2_CPUS = 49165755;
+    C2_CPUS = 317601211;
 
-    COMMITMENTS = 187706334;
+    COMMITMENTS = 456141790;
 
     COMMITTED_A2_CPUS = 59330902;
 
     COMMITTED_C2_CPUS = 223725528;
 
-    COMMITTED_CPUS = 23959246;
+    COMMITTED_CPUS = 292394702;
 
-    COMMITTED_LICENSES = 89171413;
+    COMMITTED_LICENSES = 357606869;
 
-    COMMITTED_LOCAL_SSD_TOTAL_GB = 39958024;
+    COMMITTED_LOCAL_SSD_TOTAL_GB = 308393480;
 
-    COMMITTED_MEMORY_OPTIMIZED_CPUS = 220622430;
+    COMMITTED_MEMORY_OPTIMIZED_CPUS = 489057886;
 
     COMMITTED_N2D_CPUS = 125951757;
 
-    COMMITTED_N2_CPUS = 54154147;
+    COMMITTED_N2_CPUS = 322589603;
 
-    COMMITTED_NVIDIA_A100_GPUS = 107363989;
+    COMMITTED_NVIDIA_A100_GPUS = 375799445;
 
     COMMITTED_NVIDIA_K80_GPUS = 3857188;
 
     COMMITTED_NVIDIA_P100_GPUS = 107528100;
 
-    COMMITTED_NVIDIA_P4_GPUS = 79517441;
+    COMMITTED_NVIDIA_P4_GPUS = 347952897;
 
     COMMITTED_NVIDIA_T4_GPUS = 139871237;
 
@@ -9395,43 +9395,43 @@ message Quota {
 
     CPUS = 2075595;
 
-    CPUS_ALL_REGIONS = 202475693;
+    CPUS_ALL_REGIONS = 470911149;
 
-    DISKS_TOTAL_GB = 85085087;
+    DISKS_TOTAL_GB = 353520543;
 
-    EXTERNAL_NETWORK_LB_FORWARDING_RULES = 105862809;
+    EXTERNAL_NETWORK_LB_FORWARDING_RULES = 374298265;
 
     EXTERNAL_PROTOCOL_FORWARDING_RULES = 63478888;
 
-    EXTERNAL_VPN_GATEWAYS = 4021678;
+    EXTERNAL_VPN_GATEWAYS = 272457134;
 
-    FIREWALLS = 106050387;
+    FIREWALLS = 374485843;
 
-    FORWARDING_RULES = 164233493;
+    FORWARDING_RULES = 432668949;
 
     GLOBAL_INTERNAL_ADDRESSES = 42738332;
 
     GPUS_ALL_REGIONS = 39387177;
 
-    HEALTH_CHECKS = 20912046;
+    HEALTH_CHECKS = 289347502;
 
     IMAGES = 15562360;
 
     INSTANCES = 131337822;
 
-    INSTANCE_GROUPS = 87483582;
+    INSTANCE_GROUPS = 355919038;
 
     INSTANCE_GROUP_MANAGERS = 101798192;
 
     INSTANCE_TEMPLATES = 226188271;
 
-    INTERCONNECTS = 146769285;
+    INTERCONNECTS = 415204741;
 
     INTERCONNECT_ATTACHMENTS_PER_REGION = 159968086;
 
-    INTERCONNECT_ATTACHMENTS_TOTAL_MBPS = 156654963;
+    INTERCONNECT_ATTACHMENTS_TOTAL_MBPS = 425090419;
 
-    INTERCONNECT_TOTAL_GBPS = 16906410;
+    INTERCONNECT_TOTAL_GBPS = 285341866;
 
     INTERNAL_ADDRESSES = 197899392;
 
@@ -9439,25 +9439,25 @@ message Quota {
 
     IN_PLACE_SNAPSHOTS = 151359133;
 
-    IN_USE_ADDRESSES = 133689616;
+    IN_USE_ADDRESSES = 402125072;
 
     IN_USE_BACKUP_SCHEDULES = 32786705;
 
-    IN_USE_SNAPSHOT_SCHEDULES = 193668627;
+    IN_USE_SNAPSHOT_SCHEDULES = 462104083;
 
-    LOCAL_SSD_TOTAL_GB = 62442565;
+    LOCAL_SSD_TOTAL_GB = 330878021;
 
     M1_CPUS = 37203366;
 
     M2_CPUS = 65832517;
 
-    MACHINE_IMAGES = 178551184;
+    MACHINE_IMAGES = 446986640;
 
-    N2D_CPUS = 83307914;
+    N2D_CPUS = 351743370;
 
-    N2_CPUS = 148029830;
+    N2_CPUS = 416465286;
 
-    NETWORKS = 217046021;
+    NETWORKS = 485481477;
 
     NETWORK_ENDPOINT_GROUPS = 102144909;
 
@@ -9465,9 +9465,9 @@ message Quota {
 
     NODE_GROUPS = 24624817;
 
-    NODE_TEMPLATES = 206461212;
+    NODE_TEMPLATES = 474896668;
 
-    NVIDIA_A100_GPUS = 236437522;
+    NVIDIA_A100_GPUS = 504872978;
 
     NVIDIA_K80_GPUS = 163886599;
 
@@ -9475,13 +9475,13 @@ message Quota {
 
     NVIDIA_P100_VWS_GPUS = 213970574;
 
-    NVIDIA_P4_GPUS = 15406014;
+    NVIDIA_P4_GPUS = 283841470;
 
-    NVIDIA_P4_VWS_GPUS = 259861163;
+    NVIDIA_P4_VWS_GPUS = 528296619;
 
     NVIDIA_T4_GPUS = 75759810;
 
-    NVIDIA_T4_VWS_GPUS = 51377583;
+    NVIDIA_T4_VWS_GPUS = 319813039;
 
     NVIDIA_V100_GPUS = 129293095;
 
@@ -9493,13 +9493,13 @@ message Quota {
 
     PREEMPTIBLE_NVIDIA_A100_GPUS = 68832784;
 
-    PREEMPTIBLE_NVIDIA_K80_GPUS = 106524745;
+    PREEMPTIBLE_NVIDIA_K80_GPUS = 374960201;
 
-    PREEMPTIBLE_NVIDIA_P100_GPUS = 68996895;
+    PREEMPTIBLE_NVIDIA_P100_GPUS = 337432351;
 
-    PREEMPTIBLE_NVIDIA_P100_VWS_GPUS = 45108620;
+    PREEMPTIBLE_NVIDIA_P100_VWS_GPUS = 313544076;
 
-    PREEMPTIBLE_NVIDIA_P4_GPUS = 160762172;
+    PREEMPTIBLE_NVIDIA_P4_GPUS = 429197628;
 
     PREEMPTIBLE_NVIDIA_P4_VWS_GPUS = 252981545;
 
@@ -9511,9 +9511,9 @@ message Quota {
 
     PSC_ILB_CONSUMER_FORWARDING_RULES_PER_PRODUCER_NETWORK = 231164291;
 
-    PUBLIC_ADVERTISED_PREFIXES = 202936524;
+    PUBLIC_ADVERTISED_PREFIXES = 471371980;
 
-    PUBLIC_DELEGATED_PREFIXES = 264030518;
+    PUBLIC_DELEGATED_PREFIXES = 532465974;
 
     REGIONAL_AUTOSCALERS = 29363772;
 
@@ -9523,35 +9523,35 @@ message Quota {
 
     RESOURCE_POLICIES = 83955297;
 
-    ROUTERS = 224583210;
+    ROUTERS = 493018666;
 
-    ROUTES = 7244618;
+    ROUTES = 275680074;
 
     SECURITY_POLICIES = 189518703;
 
-    SECURITY_POLICY_CEVAL_RULES = 202380233;
+    SECURITY_POLICY_CEVAL_RULES = 470815689;
 
     SECURITY_POLICY_RULES = 203549225;
 
-    SNAPSHOTS = 74969871;
+    SNAPSHOTS = 343405327;
 
     SSD_TOTAL_GB = 161732561;
 
-    SSL_CERTIFICATES = 109936943;
+    SSL_CERTIFICATES = 378372399;
 
     STATIC_ADDRESSES = 93624049;
 
-    STATIC_BYOIP_ADDRESSES = 7374193;
+    STATIC_BYOIP_ADDRESSES = 275809649;
 
-    SUBNETWORKS = 152895013;
+    SUBNETWORKS = 421330469;
 
     TARGET_HTTPS_PROXIES = 219522506;
 
     TARGET_HTTP_PROXIES = 164117155;
 
-    TARGET_INSTANCES = 16084272;
+    TARGET_INSTANCES = 284519728;
 
-    TARGET_POOLS = 79825801;
+    TARGET_POOLS = 348261257;
 
     TARGET_SSL_PROXIES = 159216235;
 
@@ -9559,7 +9559,7 @@ message Quota {
 
     TARGET_VPN_GATEWAYS = 75029928;
 
-    URL_MAPS = 110225287;
+    URL_MAPS = 378660743;
 
     VPN_GATEWAYS = 35620282;
 
@@ -9573,7 +9573,7 @@ message Quota {
   optional double limit = 102976443;
 
   // [Output Only] Name of the quota metric.
-  optional Metric metric = 264631728;
+  optional Metric metric = 533067184;
 
   // [Output Only] Owning resource. This is the resource on which this quota is applied.
   optional string owner = 106164915;
@@ -9586,10 +9586,10 @@ message Quota {
 // The location in Cloud Storage and naming method of the daily usage report. Contains bucket_name and report_name prefix.
 message UsageExportLocation {
   // The name of an existing bucket in Cloud Storage where the usage report object is stored. The Google Service Account is granted write access to this bucket. This can either be the bucket name by itself, such as example-bucket, or the bucket name with gs:// or https://storage.googleapis.com/ in front of it, such as gs://example-bucket.
-  optional string bucket_name = 15174592;
+  optional string bucket_name = 283610048;
 
   // An optional prefix for the name of the usage report object stored in bucketName. If not supplied, defaults to usage. The report is stored as a CSV file named report_name_prefix_gce_YYYYMMDD.csv where YYYYMMDD is the day of the usage according to Pacific Time. If you supply a prefix, it should conform to Cloud Storage object naming conventions.
-  optional string report_name_prefix = 51763259;
+  optional string report_name_prefix = 320198715;
 
 }
 
@@ -9602,9 +9602,9 @@ message Project {
     // A value indicating that the enum field is not set.
     UNDEFINED_DEFAULT_NETWORK_TIER = 0;
 
-    PREMIUM = 131095095;
+    PREMIUM = 399530551;
 
-    STANDARD = 216207037;
+    STANDARD = 484642493;
 
   }
 
@@ -9615,7 +9615,7 @@ message Project {
 
     HOST = 2223528;
 
-    UNSPECIFIED_XPN_PROJECT_STATUS = 71957801;
+    UNSPECIFIED_XPN_PROJECT_STATUS = 340393257;
 
   }
 
@@ -9626,16 +9626,16 @@ message Project {
   optional string creation_timestamp = 30525366;
 
   // This signifies the default network tier used for configuring resources of the project and can only take the following values: PREMIUM, STANDARD. Initially the default network tier is PREMIUM.
-  optional DefaultNetworkTier default_network_tier = 203317905;
+  optional DefaultNetworkTier default_network_tier = 471753361;
 
   // [Output Only] Default service account used by VMs running in this project.
-  optional string default_service_account = 30276773;
+  optional string default_service_account = 298712229;
 
   // An optional textual description of the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Restricted features enabled for use on this project.
-  repeated string enabled_features = 200582011;
+  repeated string enabled_features = 469017467;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server. This is not the project ID, and is just a unique ID used by Compute Engine to identify resources.
   optional string id = 3355;
@@ -9650,10 +9650,10 @@ message Project {
   repeated Quota quotas = 125341947;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // The naming prefix for daily usage reports and the Google Cloud Storage bucket where they are stored.
-  optional UsageExportLocation usage_export_location = 79108418;
+  optional UsageExportLocation usage_export_location = 347543874;
 
   // [Output Only] The role this project has in a shared VPC configuration. Currently, only projects with the host role, which is specified by the value HOST, are differentiated.
   optional XpnProjectStatus xpn_project_status = 228419265;
@@ -9667,7 +9667,7 @@ message XpnResourceId {
     // A value indicating that the enum field is not set.
     UNDEFINED_TYPE = 0;
 
-    PROJECT = 140236537;
+    PROJECT = 408671993;
 
     XPN_RESOURCE_TYPE_UNSPECIFIED = 151607034;
 
@@ -9722,14 +9722,14 @@ message ProjectsSetDefaultNetworkTierRequest {
     // A value indicating that the enum field is not set.
     UNDEFINED_NETWORK_TIER = 0;
 
-    PREMIUM = 131095095;
+    PREMIUM = 399530551;
 
-    STANDARD = 216207037;
+    STANDARD = 484642493;
 
   }
 
   // Default network tier to be set.
-  optional NetworkTier network_tier = 248962387;
+  optional NetworkTier network_tier = 517397843;
 
 }
 
@@ -9752,10 +9752,10 @@ message Region {
   optional string creation_timestamp = 30525366;
 
   // [Output Only] The deprecation status associated with this region.
-  optional DeprecationStatus deprecated = 246703539;
+  optional DeprecationStatus deprecated = 515138995;
 
   // [Output Only] Textual description of the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -9770,7 +9770,7 @@ message Region {
   repeated Quota quotas = 125341947;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Status of the region, either UP or DOWN.
   optional Status status = 181260274;
@@ -9795,7 +9795,7 @@ message RegionAutoscalerList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -9817,7 +9817,7 @@ message RegionDiskTypeList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -9841,7 +9841,7 @@ message RegionDisksRemoveResourcePoliciesRequest {
 //
 message RegionDisksResizeRequest {
   // The new size of the regional persistent disk, which is specified in GB.
-  optional string size_gb = 226493913;
+  optional string size_gb = 494929369;
 
 }
 
@@ -9860,7 +9860,7 @@ message RegionInstanceGroupList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -9889,7 +9889,7 @@ message RegionInstanceGroupManagerList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -9899,14 +9899,14 @@ message RegionInstanceGroupManagerList {
 // RegionInstanceGroupManagers.patchPerInstanceConfigs
 message RegionInstanceGroupManagerPatchInstanceConfigReq {
   // The list of per-instance configs to insert or patch on this managed instance group.
-  repeated PerInstanceConfig per_instance_configs = 257829545;
+  repeated PerInstanceConfig per_instance_configs = 526265001;
 
 }
 
 // RegionInstanceGroupManagers.updatePerInstanceConfigs
 message RegionInstanceGroupManagerUpdateInstanceConfigReq {
   // The list of per-instance configs to insert or patch on this managed instance group.
-  repeated PerInstanceConfig per_instance_configs = 257829545;
+  repeated PerInstanceConfig per_instance_configs = 526265001;
 
 }
 
@@ -9920,7 +9920,7 @@ message RegionInstanceGroupManagersAbandonInstancesRequest {
 // RegionInstanceGroupManagers.applyUpdatesToInstances
 message RegionInstanceGroupManagersApplyUpdatesRequest {
   // Flag to update all instances instead of specified list of ?instances?. If the flag is set to true then the instances may not be specified in the request.
-  optional bool all_instances = 135241056;
+  optional bool all_instances = 403676512;
 
   // The list of URLs of one or more instances for which you want to apply updates. Each URL can be a full URL or a partial URL, such as zones/[ZONE]/instances/[INSTANCE_NAME].
   repeated string instances = 29097598;
@@ -9930,7 +9930,7 @@ message RegionInstanceGroupManagersApplyUpdatesRequest {
   // - RESTART: Stop the instance and start it again.
   // - REFRESH: Do not stop the instance.
   // - NONE: Do not disrupt the instance at all.  By default, the minimum action is NONE. If your update requires a more disruptive action than you set with this flag, the necessary action is performed to execute the update.
-  optional string minimal_action = 2131604;
+  optional string minimal_action = 270567060;
 
   // The most disruptive action that you want to perform on each instance during the update:
   // - REPLACE: Delete the instance and create it again.
@@ -9981,7 +9981,7 @@ message RegionInstanceGroupManagersListInstanceConfigsResp {
 //
 message RegionInstanceGroupManagersListInstancesResponse {
   // A list of managed instances.
-  repeated ManagedInstance managed_instances = 67784158;
+  repeated ManagedInstance managed_instances = 336219614;
 
   // [Output Only] This token allows you to get the next page of results for list requests. If the number of results is larger than maxResults, use the nextPageToken as a value for the query parameter pageToken in the next list request. Subsequent list requests will have their own nextPageToken to continue paging through the results.
   optional string next_page_token = 79797525;
@@ -10001,14 +10001,14 @@ message RegionInstanceGroupManagersSetTargetPoolsRequest {
   optional string fingerprint = 234678500;
 
   // The URL of all TargetPool resources to which instances in the instanceGroup field are added. The target pools automatically apply to all of the instances in the managed instance group.
-  repeated string target_pools = 67637161;
+  repeated string target_pools = 336072617;
 
 }
 
 //
 message RegionInstanceGroupManagersSetTemplateRequest {
   // URL of the InstanceTemplate resource from which all new instances will be created.
-  optional string instance_template = 40812772;
+  optional string instance_template = 309248228;
 
 }
 
@@ -10027,7 +10027,7 @@ message RegionInstanceGroupsListInstances {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -10061,7 +10061,7 @@ message RegionInstanceGroupsSetNamedPortsRequest {
   optional string fingerprint = 234678500;
 
   // The list of named ports to set for this instance group.
-  repeated NamedPort named_ports = 159163276;
+  repeated NamedPort named_ports = 427598732;
 
 }
 
@@ -10080,7 +10080,7 @@ message RegionList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -10093,14 +10093,14 @@ message RegionSetLabelsRequest {
   optional string label_fingerprint = 178124825;
 
   // The labels to set for this resource.
-  map<string, string> labels = 231759871;
+  map<string, string> labels = 500195327;
 
 }
 
 //
 message RegionSetPolicyRequest {
   // Flatten Policy to create a backwacd compatible wire-format. Deprecated. Use 'policy' to specify bindings.
-  repeated Binding bindings = 134816398;
+  repeated Binding bindings = 403251854;
 
   // Flatten Policy to create a backward compatible wire-format. Deprecated. Use 'policy' to specify the etag.
   optional string etag = 3123477;
@@ -10113,7 +10113,7 @@ message RegionSetPolicyRequest {
 //
 message RegionTargetHttpsProxiesSetSslCertificatesRequest {
   // New set of SslCertificate resources to associate with this TargetHttpsProxy resource. Currently exactly one SslCertificate resource must be specified.
-  repeated string ssl_certificates = 97571087;
+  repeated string ssl_certificates = 366006543;
 
 }
 
@@ -10142,20 +10142,20 @@ message UrlMap {
   // Only one of defaultRouteAction or defaultUrlRedirect must be set.
   // UrlMaps for external HTTP(S) load balancers support only the urlRewrite action within defaultRouteAction.
   // defaultRouteAction has no effect when the URL map is bound to target gRPC proxy that has validateForProxyless field set to true.
-  optional HttpRouteAction default_route_action = 110484010;
+  optional HttpRouteAction default_route_action = 378919466;
 
   // The full or partial URL of the defaultService resource to which traffic is directed if none of the hostRules match. If defaultRouteAction is additionally specified, advanced routing actions like URL Rewrites, etc. take effect prior to sending the request to the backend. However, if defaultService is specified, defaultRouteAction cannot contain any weightedBackendServices. Conversely, if routeAction specifies any weightedBackendServices, service must not be specified.
   // Only one of defaultService, defaultUrlRedirect  or defaultRouteAction.weightedBackendService must be set.
   // defaultService has no effect when the URL map is bound to target gRPC proxy that has validateForProxyless field set to true.
-  optional string default_service = 101806775;
+  optional string default_service = 370242231;
 
   // When none of the specified hostRules match, the request is redirected to a URL specified by defaultUrlRedirect.
   // If defaultUrlRedirect is specified, defaultService or defaultRouteAction must not be set.
   // Not supported when the URL map is bound to target gRPC proxy.
-  optional HttpRedirectAction default_url_redirect = 91067882;
+  optional HttpRedirectAction default_url_redirect = 359503338;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Fingerprint of this resource. A hash of the contents stored in this object. This field is used in optimistic locking. This field will be ignored when inserting a UrlMap. An up-to-date fingerprint must be provided in order to update the UrlMap, otherwise the request will fail with error 412 conditionNotMet.
   //
@@ -10166,10 +10166,10 @@ message UrlMap {
   // The headerAction specified here take effect after headerAction specified under pathMatcher.
   // Note that headerAction is not supported for Loadbalancers that have their loadBalancingScheme set to EXTERNAL.
   // Not supported when the URL map is bound to target gRPC proxy that has validateForProxyless field set to true.
-  optional HttpHeaderAction header_action = 59641896;
+  optional HttpHeaderAction header_action = 328077352;
 
   // The list of HostRules to use against the URL.
-  repeated HostRule host_rules = 43369376;
+  repeated HostRule host_rules = 311804832;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -10181,13 +10181,13 @@ message UrlMap {
   optional string name = 3373707;
 
   // The list of named PathMatchers to use against the URL.
-  repeated PathMatcher path_matchers = 3228763;
+  repeated PathMatcher path_matchers = 271664219;
 
   // [Output Only] URL of the region where the regional URL map resides. This field is not applicable to global URL maps. You must specify this field as part of the HTTP request URL. It is not settable as a field in the request body.
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // The list of expected URL mapping tests. Request to update this UrlMap will succeed only if all of the test cases pass. You can specify a maximum of 100 tests per UrlMap.
   // Not supported when the URL map is bound to target gRPC proxy that has validateForProxyless field set to true.
@@ -10205,7 +10205,7 @@ message RegionUrlMapsValidateRequest {
 //
 message ReservationsScopedList {
   // A list of reservations contained in this scope.
-  repeated Reservation reservations = 131282471;
+  repeated Reservation reservations = 399717927;
 
   // Informational warning which replaces the list of reservations when the list is empty.
   optional Warning warning = 50704284;
@@ -10227,7 +10227,7 @@ message ReservationAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -10252,7 +10252,7 @@ message ReservationList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -10282,11 +10282,11 @@ message ResourcePolicy {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    CREATING = 187129529;
+    CREATING = 455564985;
 
-    DELETING = 260166568;
+    DELETING = 528602024;
 
-    INVALID = 261848535;
+    INVALID = 530283991;
 
     READY = 77848963;
 
@@ -10295,7 +10295,7 @@ message ResourcePolicy {
   // [Output Only] Creation timestamp in RFC3339 text format.
   optional string creation_timestamp = 30525366;
 
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Resource policy for instances for placement configuration.
   optional ResourcePolicyGroupPlacementPolicy group_placement_policy = 10931596;
@@ -10312,7 +10312,7 @@ message ResourcePolicy {
   optional string region = 138946292;
 
   // [Output Only] Server-defined fully-qualified URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // Resource policy for persistent disks for creating snapshots.
   optional ResourcePolicySnapshotSchedulePolicy snapshot_schedule_policy = 218131295;
@@ -10341,7 +10341,7 @@ message ResourcePolicyGroupPlacementPolicy {
 
     COLLOCATED = 103257554;
 
-    UNSPECIFIED_COLLOCATION = 195872749;
+    UNSPECIFIED_COLLOCATION = 464308205;
 
   }
 
@@ -10349,7 +10349,7 @@ message ResourcePolicyGroupPlacementPolicy {
   optional int32 availability_domain_count = 12453432;
 
   // Specifies network collocation
-  optional Collocation collocation = 242721077;
+  optional Collocation collocation = 511156533;
 
   // Number of vms in this placement group
   optional int32 vm_count = 261463431;
@@ -10362,7 +10362,7 @@ message ResourcePolicySnapshotSchedulePolicy {
   optional ResourcePolicySnapshotSchedulePolicyRetentionPolicy retention_policy = 68625779;
 
   // A Vm Maintenance Policy specifies what kind of infrastructure maintenance we are allowed to perform on this VM and when. Schedule that is applied to disks covered by this policy.
-  optional ResourcePolicySnapshotSchedulePolicySchedule schedule = 107385495;
+  optional ResourcePolicySnapshotSchedulePolicySchedule schedule = 375820951;
 
   // Properties with which snapshots are created such as labels, encryption keys.
   optional ResourcePolicySnapshotSchedulePolicySnapshotProperties snapshot_properties = 185371278;
@@ -10386,7 +10386,7 @@ message ResourcePolicyAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -10399,7 +10399,7 @@ message ResourcePolicyAggregatedList {
 // Time window specified for daily operations.
 message ResourcePolicyDailyCycle {
   // Defines a schedule with units measured in months. The value determines how many months pass between the start of each cycle.
-  optional int32 days_in_cycle = 101354548;
+  optional int32 days_in_cycle = 369790004;
 
   // [Output only] A predetermined duration for the window, automatically chosen to be the smallest possible in the given scenario.
   optional string duration = 155471252;
@@ -10415,7 +10415,7 @@ message ResourcePolicyHourlyCycle {
   optional string duration = 155471252;
 
   // Defines a schedule with units measured in hours. The value determines how many hours pass between the start of each cycle.
-  optional int32 hours_in_cycle = 258327676;
+  optional int32 hours_in_cycle = 526763132;
 
   // Time within the window to start the operations. It must be in format "HH:MM", where HH : [00-23] and MM : [00-00] GMT.
   optional string start_time = 37467274;
@@ -10439,7 +10439,7 @@ message ResourcePolicyList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -10453,7 +10453,7 @@ message ResourcePolicySnapshotSchedulePolicyRetentionPolicy {
     // A value indicating that the enum field is not set.
     UNDEFINED_ON_SOURCE_DISK_DELETE = 0;
 
-    APPLY_RETENTION_POLICY = 266635876;
+    APPLY_RETENTION_POLICY = 535071332;
 
     KEEP_AUTO_SNAPSHOTS = 258925689;
 
@@ -10462,10 +10462,10 @@ message ResourcePolicySnapshotSchedulePolicyRetentionPolicy {
   }
 
   // Maximum age of the snapshot that is allowed to be kept.
-  optional int32 max_retention_days = 55861523;
+  optional int32 max_retention_days = 324296979;
 
   // Specifies the behavior to apply to scheduled snapshots when the source disk is deleted.
-  optional OnSourceDiskDelete on_source_disk_delete = 53520073;
+  optional OnSourceDiskDelete on_source_disk_delete = 321955529;
 
 }
 
@@ -10475,7 +10475,7 @@ message ResourcePolicySnapshotSchedulePolicySchedule {
 
   optional ResourcePolicyHourlyCycle hourly_schedule = 38328485;
 
-  optional ResourcePolicyWeeklyCycle weekly_schedule = 91112597;
+  optional ResourcePolicyWeeklyCycle weekly_schedule = 359548053;
 
 }
 
@@ -10485,13 +10485,13 @@ message ResourcePolicySnapshotSchedulePolicySnapshotProperties {
   optional string chain_name = 68644169;
 
   // Indication to perform a 'guest aware' snapshot.
-  optional bool guest_flush = 117115357;
+  optional bool guest_flush = 385550813;
 
   // Labels to apply to scheduled snapshots. These can be later modified by the setLabels method. Label values may be empty.
-  map<string, string> labels = 231759871;
+  map<string, string> labels = 500195327;
 
   // Cloud Storage bucket storage location of the auto snapshot (regional or multi-regional).
-  repeated string storage_locations = 59569818;
+  repeated string storage_locations = 328005274;
 
 }
 
@@ -10509,21 +10509,21 @@ message ResourcePolicyWeeklyCycleDayOfWeek {
     // A value indicating that the enum field is not set.
     UNDEFINED_DAY = 0;
 
-    FRIDAY = 202963295;
+    FRIDAY = 471398751;
 
-    INVALID = 261848535;
+    INVALID = 530283991;
 
     MONDAY = 132310288;
 
-    SATURDAY = 10602425;
+    SATURDAY = 279037881;
 
-    SUNDAY = 41190864;
+    SUNDAY = 309626320;
 
     THURSDAY = 207198682;
 
-    TUESDAY = 9074221;
+    TUESDAY = 277509677;
 
-    WEDNESDAY = 153593654;
+    WEDNESDAY = 422029110;
 
   }
 
@@ -10546,10 +10546,10 @@ message Route {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this field when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // The destination range of outgoing packets that this route applies to. Both IPv4 and IPv6 are supported.
-  optional string dest_range = 112892256;
+  optional string dest_range = 381327712;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -10564,7 +10564,7 @@ message Route {
   optional string network = 232872494;
 
   // The URL to a gateway that should handle matching packets. You can only specify the internet gateway using a full or partial valid URL:  projects/project/global/gateways/default-internet-gateway
-  optional string next_hop_gateway = 108739842;
+  optional string next_hop_gateway = 377175298;
 
   // The URL to a forwarding rule of type loadBalancingScheme=INTERNAL that should handle matching packets or the IP address of the forwarding Rule. For example, the following are all valid URLs:
   // - 10.128.0.56
@@ -10574,7 +10574,7 @@ message Route {
 
   // The URL to an instance that should handle matching packets. You can specify this as a full or partial URL. For example:
   // https://www.googleapis.com/compute/v1/projects/project/zones/zone/instances/
-  optional string next_hop_instance = 125072791;
+  optional string next_hop_instance = 393508247;
 
   // The network IP address of an instance that should handle matching packets. Only IPv4 is supported.
   optional string next_hop_ip = 110319529;
@@ -10583,22 +10583,22 @@ message Route {
   optional string next_hop_network = 262295788;
 
   // [Output Only] The network peering name that should handle matching packets, which should conform to RFC1035.
-  optional string next_hop_peering = 144247294;
+  optional string next_hop_peering = 412682750;
 
   // The URL to a VpnTunnel that should handle matching packets.
-  optional string next_hop_vpn_tunnel = 251409045;
+  optional string next_hop_vpn_tunnel = 519844501;
 
   // The priority of this route. Priority is used to break ties in cases where there is more than one matching route of equal prefix length. In cases where multiple routes have equal prefix length, the one with the lowest-numbered priority value wins. The default value is `1000`. The priority value must be from `0` to `65535`, inclusive.
-  optional uint32 priority = 176716196;
+  optional uint32 priority = 445151652;
 
   // [Output Only] Server-defined fully-qualified URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // A list of instance tags to which this route applies.
   repeated string tags = 3552281;
 
   // [Output Only] If potential misconfigurations are detected for this route, this field will be populated with warning messages.
-  repeated Warnings warnings = 229655639;
+  repeated Warnings warnings = 498091095;
 
 }
 
@@ -10617,7 +10617,7 @@ message RouteList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -10631,7 +10631,7 @@ message RouterBgp {
     // A value indicating that the enum field is not set.
     UNDEFINED_ADVERTISE_MODE = 0;
 
-    CUSTOM = 120160113;
+    CUSTOM = 388595569;
 
     DEFAULT = 115302945;
 
@@ -10647,7 +10647,7 @@ message RouterBgp {
   }
 
   // User-specified flag to indicate which mode to use for advertisement. The options are DEFAULT or CUSTOM.
-  optional AdvertiseMode advertise_mode = 43698875;
+  optional AdvertiseMode advertise_mode = 312134331;
 
   // User-specified list of prefix groups to advertise in custom mode. This field can only be populated if advertise_mode is CUSTOM and is advertised to all peers of the router. These groups will be advertised in addition to any specified prefixes. Leave this field blank to advertise no custom groups.
   repeated AdvertisedGroups advertised_groups = 21065526;
@@ -10667,7 +10667,7 @@ message RouterBgpPeer {
     // A value indicating that the enum field is not set.
     UNDEFINED_ADVERTISE_MODE = 0;
 
-    CUSTOM = 120160113;
+    CUSTOM = 388595569;
 
     DEFAULT = 115302945;
 
@@ -10689,14 +10689,14 @@ message RouterBgpPeer {
     // A value indicating that the enum field is not set.
     UNDEFINED_MANAGEMENT_TYPE = 0;
 
-    MANAGED_BY_ATTACHMENT = 190490955;
+    MANAGED_BY_ATTACHMENT = 458926411;
 
-    MANAGED_BY_USER = 48858611;
+    MANAGED_BY_USER = 317294067;
 
   }
 
   // User-specified flag to indicate which mode to use for advertisement.
-  optional AdvertiseMode advertise_mode = 43698875;
+  optional AdvertiseMode advertise_mode = 312134331;
 
   // User-specified list of prefix groups to advertise in custom mode, which can take one of the following options:
   // - ALL_SUBNETS: Advertises all available subnets, including peer VPC subnets.
@@ -10711,10 +10711,10 @@ message RouterBgpPeer {
   optional uint32 advertised_route_priority = 186486332;
 
   // Name of the interface the BGP peer is associated with.
-  optional string interface_name = 169419217;
+  optional string interface_name = 437854673;
 
   // IP address of the interface inside Google Cloud Platform. Only IPv4 is supported.
-  optional string ip_address = 137836764;
+  optional string ip_address = 406272220;
 
   // [Output Only] The resource that configures and manages this BGP peer.
   // - MANAGED_BY_USER is the default value and can be managed by you or other users
@@ -10741,9 +10741,9 @@ message RouterInterface {
     // A value indicating that the enum field is not set.
     UNDEFINED_MANAGEMENT_TYPE = 0;
 
-    MANAGED_BY_ATTACHMENT = 190490955;
+    MANAGED_BY_ATTACHMENT = 458926411;
 
-    MANAGED_BY_USER = 48858611;
+    MANAGED_BY_USER = 317294067;
 
   }
 
@@ -10751,10 +10751,10 @@ message RouterInterface {
   optional string ip_range = 145092645;
 
   // URI of the linked Interconnect attachment. It must be in the same region as the router. Each interface can have one linked resource, which can be a VPN tunnel, an Interconnect attachment, or a virtual machine instance.
-  optional string linked_interconnect_attachment = 232650062;
+  optional string linked_interconnect_attachment = 501085518;
 
   // URI of the linked VPN tunnel, which must be in the same region as the router. Each interface can have one linked resource, which can be a VPN tunnel, an Interconnect attachment, or a virtual machine instance.
-  optional string linked_vpn_tunnel = 83861497;
+  optional string linked_vpn_tunnel = 352296953;
 
   // [Output Only] The resource that configures and manages this interface.
   // - MANAGED_BY_USER is the default value and can be managed directly by users.
@@ -10793,12 +10793,12 @@ message RouterNat {
 
     ALL_SUBNETWORKS_ALL_PRIMARY_IP_RANGES = 185573819;
 
-    LIST_OF_SUBNETWORKS = 249106814;
+    LIST_OF_SUBNETWORKS = 517542270;
 
   }
 
   // A list of URLs of the IP resources to be drained. These IPs must be valid static external IPs that have been assigned to the NAT. These IPs should be used for updating/patching a NAT only.
-  repeated string drain_nat_ips = 235643079;
+  repeated string drain_nat_ips = 504078535;
 
   optional bool enable_endpoint_independent_mapping = 259441819;
 
@@ -10806,7 +10806,7 @@ message RouterNat {
   optional int32 icmp_idle_timeout_sec = 3647562;
 
   // Configure logging on this NAT.
-  optional RouterNatLogConfig log_config = 82864285;
+  optional RouterNatLogConfig log_config = 351299741;
 
   // Minimum number of ports allocated to a VM from this NAT config. If not set, a default number of ports is allocated to a VM. This is rounded up to the nearest power of 2. For example, if the value of this field is 50, at least 64 ports are allocated to a VM.
   optional int32 min_ports_per_vm = 186193587;
@@ -10817,7 +10817,7 @@ message RouterNat {
   // Specify the NatIpAllocateOption, which can take one of the following values:
   // - MANUAL_ONLY: Uses only Nat IP addresses provided by customers. When there are not enough specified Nat IPs, the Nat service fails for new VMs.
   // - AUTO_ONLY: Nat IPs are allocated by Google Cloud Platform; customers can't specify any Nat IPs. When choosing AUTO_ONLY, then nat_ip should be empty.
-  optional NatIpAllocateOption nat_ip_allocate_option = 161291389;
+  optional NatIpAllocateOption nat_ip_allocate_option = 429726845;
 
   // A list of URLs of the IP resources used for this Nat service. These IP addresses must be valid static external IP addresses assigned to the project.
   repeated string nat_ips = 117635086;
@@ -10829,7 +10829,7 @@ message RouterNat {
   optional SourceSubnetworkIpRangesToNat source_subnetwork_ip_ranges_to_nat = 252213211;
 
   // A list of Subnetwork resources whose traffic should be translated by NAT Gateway. It is used only when LIST_OF_SUBNETWORKS is selected for the SubnetworkIpRangeToNatOption above.
-  repeated RouterNatSubnetworkToNat subnetworks = 147417669;
+  repeated RouterNatSubnetworkToNat subnetworks = 415853125;
 
   // Timeout (in seconds) for TCP established connections. Defaults to 1200s if not set.
   optional int32 tcp_established_idle_timeout_sec = 223098349;
@@ -10850,13 +10850,13 @@ message Router {
   optional RouterBgp bgp = 97483;
 
   // BGP information that must be configured into the routing stack to establish BGP peering. This information must specify the peer ASN and either the interface name, IP address, or peer IP address. Please refer to RFC4273.
-  repeated RouterBgpPeer bgp_peers = 184260317;
+  repeated RouterBgpPeer bgp_peers = 452695773;
 
   // [Output Only] Creation timestamp in RFC3339 text format.
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -10880,14 +10880,14 @@ message Router {
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
 }
 
 // Description-tagged IP ranges for the router to advertise.
 message RouterAdvertisedIpRange {
   // User-specified description for the IP range.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // The IP range to advertise. The value must be a CIDR-formatted string.
   optional string range = 108280125;
@@ -10897,7 +10897,7 @@ message RouterAdvertisedIpRange {
 //
 message RoutersScopedList {
   // A list of routers contained in this scope.
-  repeated Router routers = 43471434;
+  repeated Router routers = 311906890;
 
   // Informational warning which replaces the list of routers when the list is empty.
   optional Warning warning = 50704284;
@@ -10919,7 +10919,7 @@ message RouterAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -10944,7 +10944,7 @@ message RouterList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -10963,20 +10963,20 @@ message RouterNatLogConfig {
 
     ALL = 64897;
 
-    ERRORS_ONLY = 39049216;
+    ERRORS_ONLY = 307484672;
 
-    TRANSLATIONS_ONLY = 88777193;
+    TRANSLATIONS_ONLY = 357212649;
 
   }
 
   // Indicates whether or not to export logs. This is false by default.
-  optional bool enable = 43328899;
+  optional bool enable = 311764355;
 
   // Specify the desired filtering of logs on this NAT. If unspecified, logs are exported for all connections handled by this NAT. This option can take one of the following values:
   // - ERRORS_ONLY: Export logs only for connection failures.
   // - TRANSLATIONS_ONLY: Export logs only for successful connections.
   // - ALL: Export logs for all connections, successful and unsuccessful.
-  optional Filter filter = 67685240;
+  optional Filter filter = 336120696;
 
 }
 
@@ -10991,7 +10991,7 @@ message RouterNatSubnetworkToNat {
 
     LIST_OF_SECONDARY_IP_RANGES = 192289308;
 
-    PRIMARY_IP_RANGE = 28674498;
+    PRIMARY_IP_RANGE = 297109954;
 
   }
 
@@ -11002,7 +11002,7 @@ message RouterNatSubnetworkToNat {
   repeated string secondary_ip_range_names = 264315097;
 
   // Specify the options for NAT ranges in the Subnetwork. All options of a single value are valid except NAT_IP_RANGE_OPTION_UNSPECIFIED. The only valid option with multiple values is: ["PRIMARY_IP_RANGE", "LIST_OF_SECONDARY_IP_RANGES"] Default: [ALL_IP_RANGES]
-  repeated SourceIpRangesToNat source_ip_ranges_to_nat = 119874930;
+  repeated SourceIpRangesToNat source_ip_ranges_to_nat = 388310386;
 
 }
 
@@ -11015,20 +11015,20 @@ message RouterStatusBgpPeerStatus {
 
     DOWN = 2104482;
 
-    UNKNOWN = 164706346;
+    UNKNOWN = 433141802;
 
     UP = 2715;
 
   }
 
   // Routes that were advertised to the remote BGP peer
-  repeated Route advertised_routes = 64957612;
+  repeated Route advertised_routes = 333393068;
 
   // IP address of the local BGP interface.
-  optional string ip_address = 137836764;
+  optional string ip_address = 406272220;
 
   // URL of the VPN tunnel that this BGP peer controls.
-  optional string linked_vpn_tunnel = 83861497;
+  optional string linked_vpn_tunnel = 352296953;
 
   // Name of this BGP peer. Unique within the Routers resource.
   optional string name = 3373707;
@@ -11056,35 +11056,35 @@ message RouterStatusBgpPeerStatus {
 // Status of a NAT contained in this router.
 message RouterStatusNatStatus {
   // A list of IPs auto-allocated for NAT. Example: ["1.1.1.1", "129.2.16.89"]
-  repeated string auto_allocated_nat_ips = 242358790;
+  repeated string auto_allocated_nat_ips = 510794246;
 
   // A list of IPs auto-allocated for NAT that are in drain mode. Example: ["1.1.1.1", "179.12.26.133"].
-  repeated string drain_auto_allocated_nat_ips = 40749101;
+  repeated string drain_auto_allocated_nat_ips = 309184557;
 
   // A list of IPs user-allocated for NAT that are in drain mode. Example: ["1.1.1.1", "179.12.26.133"].
-  repeated string drain_user_allocated_nat_ips = 36833097;
+  repeated string drain_user_allocated_nat_ips = 305268553;
 
   // The number of extra IPs to allocate. This will be greater than 0 only if user-specified IPs are NOT enough to allow all configured VMs to use NAT. This value is meaningful only when auto-allocation of NAT IPs is *not* used.
-  optional int32 min_extra_nat_ips_needed = 97350882;
+  optional int32 min_extra_nat_ips_needed = 365786338;
 
   // Unique name of this NAT.
   optional string name = 3373707;
 
   // Number of VM endpoints (i.e., Nics) that can use NAT.
-  optional int32 num_vm_endpoints_with_nat_mappings = 243932012;
+  optional int32 num_vm_endpoints_with_nat_mappings = 512367468;
 
   // A list of fully qualified URLs of reserved IP address resources.
   repeated string user_allocated_nat_ip_resources = 212776151;
 
   // A list of IPs user-allocated for NAT. They will be raw IP strings like "179.12.26.133".
-  repeated string user_allocated_nat_ips = 238442786;
+  repeated string user_allocated_nat_ips = 506878242;
 
 }
 
 //
 message RouterStatus {
   // Best routes for this router's network.
-  repeated Route best_routes = 127391237;
+  repeated Route best_routes = 395826693;
 
   // Best routes learned by this router.
   repeated Route best_routes_for_router = 119389689;
@@ -11143,7 +11143,7 @@ message SchedulingNodeAffinity {
 // An instance's screenshot.
 message Screenshot {
   // [Output Only] The Base64-encoded screenshot data.
-  optional string contents = 237984538;
+  optional string contents = 506419994;
 
   // [Output Only] Type of the resource. Always compute#screenshot for the screenshots.
   optional string kind = 3292052;
@@ -11158,7 +11158,7 @@ message SecurityPoliciesWafConfig {
 
 //
 message SecurityPoliciesListPreconfiguredExpressionSetsResponse {
-  optional SecurityPoliciesWafConfig preconfigured_expression_sets = 267765370;
+  optional SecurityPoliciesWafConfig preconfigured_expression_sets = 536200826;
 
 }
 
@@ -11168,7 +11168,7 @@ message SecurityPolicyRule {
   optional string action = 187661878;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output only] Type of the resource. Always compute#securityPolicyRule for security policy rules
   optional string kind = 3292052;
@@ -11180,7 +11180,7 @@ message SecurityPolicyRule {
   optional bool preview = 218686408;
 
   // An integer indicating the priority of a rule in the list. The priority must be a positive value between 0 and 2147483647. Rules are evaluated from highest to lowest priority where 0 is the highest priority and 2147483647 is the lowest priority.
-  optional int32 priority = 176716196;
+  optional int32 priority = 445151652;
 
 }
 
@@ -11192,7 +11192,7 @@ message SecurityPolicy {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Specifies a fingerprint for this resource, which is essentially a hash of the metadata's contents and used for optimistic locking. The fingerprint is initially generated by Compute Engine and changes after every request to modify or update metadata. You must always provide an up-to-date fingerprint hash in order to update or change metadata, otherwise the request will fail with error 412 conditionNotMet.
   //
@@ -11212,7 +11212,7 @@ message SecurityPolicy {
   repeated SecurityPolicyRule rules = 108873975;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
 }
 
@@ -11259,21 +11259,21 @@ message SecurityPolicyRuleMatcher {
   optional Expr expr = 3127797;
 
   // Preconfigured versioned expression. If this field is specified, config must also be specified. Available preconfigured expressions along with their requirements are: SRC_IPS_V1 - must specify the corresponding src_ip_range field in config.
-  optional VersionedExpr versioned_expr = 53850557;
+  optional VersionedExpr versioned_expr = 322286013;
 
 }
 
 //
 message SecurityPolicyRuleMatcherConfig {
   // CIDR IP address range. Maximum number of src_ip_ranges allowed is 10.
-  repeated string src_ip_ranges = 163692627;
+  repeated string src_ip_ranges = 432128083;
 
 }
 
 // An instance's serial console output.
 message SerialPortOutput {
   // [Output Only] The contents of the console output.
-  optional string contents = 237984538;
+  optional string contents = 506419994;
 
   // [Output Only] Type of the resource. Always compute#serialPortOutput for serial port output.
   optional string kind = 3292052;
@@ -11282,7 +11282,7 @@ message SerialPortOutput {
   optional string next = 3377907;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // The starting byte position of the output that was returned. This should match the start parameter sent with the request. If the serial console output exceeds the size of the buffer (1 MB), older output is overwritten by newer content. The output start value will indicate the byte position of the output that was returned, which might be different than the `start` value that was specified in the request.
   optional string start = 109757538;
@@ -11292,33 +11292,33 @@ message SerialPortOutput {
 // A Shielded Instance Identity Entry.
 message ShieldedInstanceIdentityEntry {
   // A PEM-encoded X.509 certificate. This field can be empty.
-  optional string ek_cert = 181743133;
+  optional string ek_cert = 450178589;
 
   // A PEM-encoded public key.
-  optional string ek_pub = 40512484;
+  optional string ek_pub = 308947940;
 
 }
 
 // A shielded Instance identity entry.
 message ShieldedInstanceIdentity {
   // An Endorsement Key (EK) made by the RSA 2048 algorithm issued to the Shielded Instance's vTPM.
-  optional ShieldedInstanceIdentityEntry encryption_key = 219833251;
+  optional ShieldedInstanceIdentityEntry encryption_key = 488268707;
 
   // [Output Only] Type of the resource. Always compute#shieldedInstanceIdentity for shielded Instance identity entry.
   optional string kind = 3292052;
 
   // An Attestation Key (AK) made by the RSA 2048 algorithm issued to the Shielded Instance's vTPM.
-  optional ShieldedInstanceIdentityEntry signing_key = 52512805;
+  optional ShieldedInstanceIdentityEntry signing_key = 320948261;
 
 }
 
 // Represents a customer-supplied Signing Key used by Cloud CDN Signed URLs
 message SignedUrlKey {
   // Name of the key. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
-  optional string key_name = 232503403;
+  optional string key_name = 500938859;
 
   // 128-bit key value used for signing the URL. The key value must be a valid RFC 4648 Section 5 base64url encoded string.
-  optional string key_value = 235671441;
+  optional string key_value = 504106897;
 
 }
 
@@ -11331,11 +11331,11 @@ message Snapshot {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    CREATING = 187129529;
+    CREATING = 455564985;
 
-    DELETING = 260166568;
+    DELETING = 528602024;
 
-    FAILED = 187271229;
+    FAILED = 455706685;
 
     READY = 77848963;
 
@@ -11348,14 +11348,14 @@ message Snapshot {
     // A value indicating that the enum field is not set.
     UNDEFINED_STORAGE_BYTES_STATUS = 0;
 
-    UPDATING = 226178886;
+    UPDATING = 494614342;
 
     UP_TO_DATE = 101306702;
 
   }
 
   // [Output Only] Set to true if snapshots are automatically created by applying resource policy on the target disk.
-  optional bool auto_created = 195486808;
+  optional bool auto_created = 463922264;
 
   // Creates the new snapshot in the snapshot chain labeled with the specified name. The chain name must be 1-63 characters long and comply with RFC1035. This is an uncommon option only for advanced service owners who needs to create separate snapshot chains, for example, for chargeback tracking. When you describe your snapshot resource, this field is visible only if it has a non-empty value.
   optional string chain_name = 68644169;
@@ -11364,13 +11364,13 @@ message Snapshot {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] Size of the source disk, specified in GB.
-  optional string disk_size_gb = 47828279;
+  optional string disk_size_gb = 316263735;
 
   // [Output Only] Number of bytes downloaded to restore a snapshot to a disk.
-  optional string download_bytes = 166618612;
+  optional string download_bytes = 435054068;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -11384,19 +11384,19 @@ message Snapshot {
   optional string label_fingerprint = 178124825;
 
   // Labels to apply to this snapshot. These can be later modified by the setLabels method. Label values may be empty.
-  map<string, string> labels = 231759871;
+  map<string, string> labels = 500195327;
 
   // [Output Only] Integer license codes indicating which licenses are attached to this snapshot.
   repeated string license_codes = 45482664;
 
   // [Output Only] A list of public visible licenses that apply to this snapshot. This can be because the original image had licenses attached (such as a Windows image).
-  repeated string licenses = 69207122;
+  repeated string licenses = 337642578;
 
   // Name of the resource; provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
   optional string name = 3373707;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // Encrypts the snapshot using a customer-supplied encryption key.
   //
@@ -11408,25 +11408,25 @@ message Snapshot {
   optional CustomerEncryptionKey snapshot_encryption_key = 43334526;
 
   // The source disk used to create this snapshot.
-  optional string source_disk = 183318337;
+  optional string source_disk = 451753793;
 
   // The customer-supplied encryption key of the source disk. Required if the source disk is protected by a customer-supplied encryption key.
-  optional CustomerEncryptionKey source_disk_encryption_key = 263065697;
+  optional CustomerEncryptionKey source_disk_encryption_key = 531501153;
 
   // [Output Only] The ID value of the disk used to create this snapshot. This value may be used to determine whether the snapshot was taken from the current or a previous instance of a given disk name.
-  optional string source_disk_id = 185755353;
+  optional string source_disk_id = 454190809;
 
   // [Output Only] The status of the snapshot. This can be CREATING, DELETING, FAILED, READY, or UPLOADING.
   optional Status status = 181260274;
 
   // [Output Only] A size of the storage used by the snapshot. As snapshots share storage, this number is expected to change with snapshot creation/deletion.
-  optional string storage_bytes = 156196263;
+  optional string storage_bytes = 424631719;
 
   // [Output Only] An indicator whether storageBytes is in a stable state or it is being adjusted as a result of shared storage reallocation. This status can either be UPDATING, meaning the size of the snapshot is being updated, or UP_TO_DATE, meaning the size of the snapshot is up-to-date.
-  optional StorageBytesStatus storage_bytes_status = 222303626;
+  optional StorageBytesStatus storage_bytes_status = 490739082;
 
   // Cloud Storage bucket storage location of the snapshot (regional or multi-regional).
-  repeated string storage_locations = 59569818;
+  repeated string storage_locations = 328005274;
 
 }
 
@@ -11445,7 +11445,7 @@ message SnapshotList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -11459,22 +11459,22 @@ message SslCertificateManagedSslCertificate {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    ACTIVE = 46297862;
+    ACTIVE = 314733318;
 
-    MANAGED_CERTIFICATE_STATUS_UNSPECIFIED = 206365394;
+    MANAGED_CERTIFICATE_STATUS_UNSPECIFIED = 474800850;
 
-    PROVISIONING = 22461165;
+    PROVISIONING = 290896621;
 
     PROVISIONING_FAILED = 76813775;
 
-    PROVISIONING_FAILED_PERMANENTLY = 6600747;
+    PROVISIONING_FAILED_PERMANENTLY = 275036203;
 
-    RENEWAL_FAILED = 166223620;
+    RENEWAL_FAILED = 434659076;
 
   }
 
   // [Output only] Detailed statuses of the domains specified for managed certificate resource.
-  map<string, string> domain_status = 91870157;
+  map<string, string> domain_status = 360305613;
 
   // The domains for which a managed SSL certificate will be generated. Currently only single-domain certs are supported.
   repeated string domains = 226935855;
@@ -11487,10 +11487,10 @@ message SslCertificateManagedSslCertificate {
 // Configuration and status of a self-managed SSL certificate.
 message SslCertificateSelfManagedSslCertificate {
   // A local certificate file. The certificate must be in PEM format. The certificate chain must be no greater than 5 certs long. The chain must include at least one intermediate cert.
-  optional string certificate = 73351575;
+  optional string certificate = 341787031;
 
   // A write-only private key in PEM format. Only insert requests will include this field.
-  optional string private_key = 92895651;
+  optional string private_key = 361331107;
 
 }
 
@@ -11515,25 +11515,25 @@ message SslCertificate {
     // A value indicating that the enum field is not set.
     UNDEFINED_TYPE = 0;
 
-    MANAGED = 211065727;
+    MANAGED = 479501183;
 
-    SELF_MANAGED = 166002060;
+    SELF_MANAGED = 434437516;
 
-    TYPE_UNSPECIFIED = 169278866;
+    TYPE_UNSPECIFIED = 437714322;
 
   }
 
   // A value read into memory from a certificate file. The certificate file must be in PEM format. The certificate chain must be no greater than 5 certs long. The chain must include at least one intermediate cert.
-  optional string certificate = 73351575;
+  optional string certificate = 341787031;
 
   // [Output Only] Creation timestamp in RFC3339 text format.
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] Expire time of the certificate. RFC3339
-  optional string expire_time = 172255725;
+  optional string expire_time = 440691181;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -11542,25 +11542,25 @@ message SslCertificate {
   optional string kind = 3292052;
 
   // Configuration and status of a managed SSL certificate.
-  optional SslCertificateManagedSslCertificate managed = 29953951;
+  optional SslCertificateManagedSslCertificate managed = 298389407;
 
   // Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
   optional string name = 3373707;
 
   // A value read into memory from a write-only private key file. The private key file must be in PEM format. For security, only insert requests include this field.
-  optional string private_key = 92895651;
+  optional string private_key = 361331107;
 
   // [Output Only] URL of the region where the regional SSL Certificate resides. This field is not applicable to global SSL Certificate.
   optional string region = 138946292;
 
   // [Output only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // Configuration and status of a self-managed SSL certificate.
-  optional SslCertificateSelfManagedSslCertificate self_managed = 60848556;
+  optional SslCertificateSelfManagedSslCertificate self_managed = 329284012;
 
   // [Output Only] Domains associated with the certificate via Subject Alternative Name.
-  repeated string subject_alternative_names = 260372451;
+  repeated string subject_alternative_names = 528807907;
 
   // (Optional) Specifies the type of SSL certificate, either "SELF_MANAGED" or "MANAGED". If not specified, the certificate is self-managed and the fields certificate and private_key are used.
   optional Type type = 3575610;
@@ -11570,7 +11570,7 @@ message SslCertificate {
 //
 message SslCertificatesScopedList {
   // List of SslCertificates contained in this scope.
-  repeated SslCertificate ssl_certificates = 97571087;
+  repeated SslCertificate ssl_certificates = 366006543;
 
   // Informational warning which replaces the list of backend services when the list is empty.
   optional Warning warning = 50704284;
@@ -11592,7 +11592,7 @@ message SslCertificateAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -11617,7 +11617,7 @@ message SslCertificateList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -11648,7 +11648,7 @@ message SslPolicy {
 
     COMPATIBLE = 179357396;
 
-    CUSTOM = 120160113;
+    CUSTOM = 388595569;
 
     MODERN = 132013855;
 
@@ -11664,10 +11664,10 @@ message SslPolicy {
   repeated string custom_features = 34789707;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The list of features enabled in the SSL policy.
-  repeated string enabled_features = 200582011;
+  repeated string enabled_features = 469017467;
 
   // Fingerprint of this resource. A hash of the contents stored in this object. This field is used in optimistic locking. This field will be ignored when inserting a SslPolicy. An up-to-date fingerprint must be provided in order to update the SslPolicy, otherwise the request will fail with error 412 conditionNotMet.
   //
@@ -11690,10 +11690,10 @@ message SslPolicy {
   optional Profile profile = 227445161;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] If potential misconfigurations are detected for this SSL policy, this field will be populated with warning messages.
-  repeated Warnings warnings = 229655639;
+  repeated Warnings warnings = 498091095;
 
 }
 
@@ -11712,7 +11712,7 @@ message SslPoliciesList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -11728,7 +11728,7 @@ message SslPoliciesListAvailableFeaturesResponse {
 //
 message SslPolicyReference {
   // URL of the SSL policy resource. Set this to empty string to clear any existing SSL policy associated with the target proxy resource.
-  optional string ssl_policy = 26754757;
+  optional string ssl_policy = 295190213;
 
 }
 
@@ -11753,7 +11753,7 @@ message StatefulPolicyPreservedStateDiskDevice {
   }
 
   // These stateful disks will never be deleted during autohealing, update or VM instance recreate operations. This flag is used to configure if the disk should be deleted after it is no longer used by the group, e.g. when the given instance or the whole group is deleted. Note: disks attached in READ_ONLY mode cannot be auto-deleted.
-  optional AutoDelete auto_delete = 196325947;
+  optional AutoDelete auto_delete = 464761403;
 
 }
 
@@ -11764,9 +11764,9 @@ message SubnetworkLogConfig {
     // A value indicating that the enum field is not set.
     UNDEFINED_AGGREGATION_INTERVAL = 0;
 
-    INTERVAL_10_MIN = 218720460;
+    INTERVAL_10_MIN = 487155916;
 
-    INTERVAL_15_MIN = 223338065;
+    INTERVAL_15_MIN = 491773521;
 
     INTERVAL_1_MIN = 69052714;
 
@@ -11785,7 +11785,7 @@ message SubnetworkLogConfig {
 
     CUSTOM_METADATA = 62450749;
 
-    EXCLUDE_ALL_METADATA = 66084498;
+    EXCLUDE_ALL_METADATA = 334519954;
 
     INCLUDE_ALL_METADATA = 164619908;
 
@@ -11795,19 +11795,19 @@ message SubnetworkLogConfig {
   optional AggregationInterval aggregation_interval = 174919042;
 
   // Whether to enable flow logging for this subnetwork. If this field is not explicitly set, it will not appear in get listings. If not set the default behavior is to disable flow logging.
-  optional bool enable = 43328899;
+  optional bool enable = 311764355;
 
   // Can only be specified if VPC flow logs for this subnetwork is enabled. Export filter used to define which VPC flow logs should be logged.
   optional string filter_expr = 183374428;
 
   // Can only be specified if VPC flow logging for this subnetwork is enabled. The value of the field must be in [0, 1]. Set the sampling rate of VPC flow logs within the subnetwork where 1.0 means all collected logs are reported and 0.0 means no logs are reported. Default is 0.5, which means half of all collected logs are reported.
-  optional float flow_sampling = 261714904;
+  optional float flow_sampling = 530150360;
 
   // Can only be specified if VPC flow logs for this subnetwork is enabled. Configures whether all, none or a subset of metadata fields should be added to the reported VPC flow logs. Default is INCLUDE_ALL_METADATA.
   optional Metadata metadata = 86866735;
 
   // Can only be specified if VPC flow logs for this subnetwork is enabled and "metadata" was set to CUSTOM_METADATA.
-  repeated string metadata_fields = 110026185;
+  repeated string metadata_fields = 378461641;
 
 }
 
@@ -11817,7 +11817,7 @@ message SubnetworkSecondaryRange {
   optional string ip_cidr_range = 98117322;
 
   // The name associated with this subnetwork secondary range, used when adding an alias IP range to a VM instance. The name must be 1-63 characters long, and comply with RFC1035. The name must be unique within the subnetwork.
-  optional string range_name = 63780941;
+  optional string range_name = 332216397;
 
 }
 
@@ -11832,11 +11832,11 @@ message Subnetwork {
     // A value indicating that the enum field is not set.
     UNDEFINED_PRIVATE_IPV6_GOOGLE_ACCESS = 0;
 
-    DISABLE_GOOGLE_ACCESS = 182523123;
+    DISABLE_GOOGLE_ACCESS = 450958579;
 
-    ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE = 159540538;
+    ENABLE_BIDIRECTIONAL_ACCESS_TO_GOOGLE = 427975994;
 
-    ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE = 19774807;
+    ENABLE_OUTBOUND_VM_ACCESS_TO_GOOGLE = 288210263;
 
   }
 
@@ -11847,7 +11847,7 @@ message Subnetwork {
 
     INTERNAL_HTTPS_LOAD_BALANCER = 248748889;
 
-    PRIVATE = 135049571;
+    PRIVATE = 403485027;
 
     PRIVATE_RFC_1918 = 254902107;
 
@@ -11858,9 +11858,9 @@ message Subnetwork {
     // A value indicating that the enum field is not set.
     UNDEFINED_ROLE = 0;
 
-    ACTIVE = 46297862;
+    ACTIVE = 314733318;
 
-    BACKUP = 72575426;
+    BACKUP = 341010882;
 
   }
 
@@ -11869,7 +11869,7 @@ message Subnetwork {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATE = 0;
 
-    DRAINING = 212019946;
+    DRAINING = 480455402;
 
     READY = 77848963;
 
@@ -11879,7 +11879,7 @@ message Subnetwork {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource. This field can be set only at resource creation time.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Whether to enable flow logging for this subnetwork. If this field is not explicitly set, it will not appear in get listings. If not set the default behavior is to disable flow logging. This field isn't supported with the purpose field set to INTERNAL_HTTPS_LOAD_BALANCER.
   optional bool enable_flow_logs = 151544420;
@@ -11890,7 +11890,7 @@ message Subnetwork {
   optional string fingerprint = 234678500;
 
   // [Output Only] The gateway address for default routes to reach destination addresses outside this subnetwork.
-  optional string gateway_address = 191431929;
+  optional string gateway_address = 459867385;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -11899,13 +11899,13 @@ message Subnetwork {
   optional string ip_cidr_range = 98117322;
 
   // [Output Only] The range of internal IPv6 addresses that are owned by this subnetwork.
-  optional string ipv6_cidr_range = 4705802;
+  optional string ipv6_cidr_range = 273141258;
 
   // [Output Only] Type of the resource. Always compute#subnetwork for Subnetwork resources.
   optional string kind = 3292052;
 
   // This field denotes the VPC flow logging options for this subnetwork. If logging is enabled, logs are exported to Cloud Logging.
-  optional SubnetworkLogConfig log_config = 82864285;
+  optional SubnetworkLogConfig log_config = 351299741;
 
   // The name of the resource, provided by the client when initially creating the resource. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
   optional string name = 3373707;
@@ -11914,7 +11914,7 @@ message Subnetwork {
   optional string network = 232872494;
 
   // Whether the VMs in this subnet can access Google services without assigned external IP addresses. This field can be both set at resource creation time and updated using setPrivateIpGoogleAccess.
-  optional bool private_ip_google_access = 153056334;
+  optional bool private_ip_google_access = 421491790;
 
   // The private IPv6 google access type for the VMs in this subnet. This is an expanded field of enablePrivateV6Access. If both fields are set, privateIpv6GoogleAccess will take priority.
   //
@@ -11922,7 +11922,7 @@ message Subnetwork {
   optional PrivateIpv6GoogleAccess private_ipv6_google_access = 48277006;
 
   // The purpose of the resource. This field can be either PRIVATE_RFC_1918 or INTERNAL_HTTPS_LOAD_BALANCER. A subnetwork with purpose set to INTERNAL_HTTPS_LOAD_BALANCER is a user-created subnetwork that is reserved for Internal HTTP(S) Load Balancing. If unspecified, the purpose defaults to PRIVATE_RFC_1918. The enableFlowLogs field isn't supported with the purpose field set to INTERNAL_HTTPS_LOAD_BALANCER.
-  optional Purpose purpose = 47971614;
+  optional Purpose purpose = 316407070;
 
   // URL of the region where the Subnetwork resides. This field can be set only at resource creation time.
   optional string region = 138946292;
@@ -11934,7 +11934,7 @@ message Subnetwork {
   repeated SubnetworkSecondaryRange secondary_ip_ranges = 136658915;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The state of the subnetwork, which can be one of the following values: READY: Subnetwork is created and ready to use DRAINING: only applicable to subnetworks that have the purpose set to INTERNAL_HTTPS_LOAD_BALANCER and indicates that connections to the load balancer are being drained. A subnetwork that is draining cannot be used or modified until it reaches a status of READY CREATING: Subnetwork is provisioning DELETING: Subnetwork is being deleted UPDATING: Subnetwork is being updated
   optional State state = 109757585;
@@ -11944,7 +11944,7 @@ message Subnetwork {
 //
 message SubnetworksScopedList {
   // A list of subnetworks contained in this scope.
-  repeated Subnetwork subnetworks = 147417669;
+  repeated Subnetwork subnetworks = 415853125;
 
   // An informational warning that appears when the list of addresses is empty.
   optional Warning warning = 50704284;
@@ -11966,7 +11966,7 @@ message SubnetworkAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -11991,7 +11991,7 @@ message SubnetworkList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -12007,7 +12007,7 @@ message SubnetworksExpandIpCidrRangeRequest {
 
 //
 message SubnetworksSetPrivateIpGoogleAccessRequest {
-  optional bool private_ip_google_access = 153056334;
+  optional bool private_ip_google_access = 421491790;
 
 }
 
@@ -12019,7 +12019,7 @@ message TargetGrpcProxy {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Fingerprint of this resource. A hash of the contents stored in this object. This field is used in optimistic locking. This field will be ignored when inserting a TargetGrpcProxy. An up-to-date fingerprint must be provided in order to patch/update the TargetGrpcProxy; otherwise, the request will fail with error 412 conditionNotMet. To see the latest fingerprint, make a get() request to retrieve the TargetGrpcProxy.
   optional string fingerprint = 234678500;
@@ -12034,13 +12034,13 @@ message TargetGrpcProxy {
   optional string name = 3373707;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Server-defined URL with id for the resource.
   optional string self_link_with_id = 44520962;
 
   // URL to the UrlMap resource that defines the mapping from URL to the BackendService. The protocol field in the BackendService must be set to GRPC.
-  optional string url_map = 98585228;
+  optional string url_map = 367020684;
 
   // If true, indicates that the BackendServices referenced by the urlMap may be accessed by gRPC applications without using a sidecar proxy. This will enable configuration checks on urlMap and its referenced BackendServices to not allow unsupported features. A gRPC application must use "xds:///" scheme in the target URI of the service it is connecting to. If false, indicates that the BackendServices referenced by the urlMap will be accessed by gRPC applications via a sidecar proxy. In this case, a gRPC application must not use "xds:///" scheme in the target URI of the service it is connecting to
   optional bool validate_for_proxyless = 101822888;
@@ -12062,7 +12062,7 @@ message TargetGrpcProxyList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -12085,7 +12085,7 @@ message TargetHttpProxy {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Fingerprint of this resource. A hash of the contents stored in this object. This field is used in optimistic locking. This field will be ignored when inserting a TargetHttpProxy. An up-to-date fingerprint must be provided in order to patch/update the TargetHttpProxy; otherwise, the request will fail with error 412 conditionNotMet. To see the latest fingerprint, make a get() request to retrieve the TargetHttpProxy.
   optional string fingerprint = 234678500;
@@ -12104,16 +12104,16 @@ message TargetHttpProxy {
   // When this field is set to true, Envoy proxies set up inbound traffic interception and bind to the IP address and port specified in the forwarding rule. This is generally useful when using Traffic Director to configure Envoy as a gateway or middle proxy (in other words, not a sidecar proxy). The Envoy proxy listens for inbound requests and handles requests when it receives them.
   //
   // The default is false.
-  optional bool proxy_bind = 17590126;
+  optional bool proxy_bind = 286025582;
 
   // [Output Only] URL of the region where the regional Target HTTP Proxy resides. This field is not applicable to global Target HTTP Proxies.
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // URL to the UrlMap resource that defines the mapping from URL to the BackendService.
-  optional string url_map = 98585228;
+  optional string url_map = 367020684;
 
 }
 
@@ -12142,7 +12142,7 @@ message TargetHttpProxyAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -12164,7 +12164,7 @@ message TargetHttpProxyList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -12195,7 +12195,7 @@ message TargetHttpsProxy {
 
     DISABLE = 241807048;
 
-    ENABLE = 170400131;
+    ENABLE = 438835587;
 
     NONE = 2402104;
 
@@ -12211,7 +12211,7 @@ message TargetHttpsProxy {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -12227,7 +12227,7 @@ message TargetHttpsProxy {
   // When this field is set to true, Envoy proxies set up inbound traffic interception and bind to the IP address and port specified in the forwarding rule. This is generally useful when using Traffic Director to configure Envoy as a gateway or middle proxy (in other words, not a sidecar proxy). The Envoy proxy listens for inbound requests and handles requests when it receives them.
   //
   // The default is false.
-  optional bool proxy_bind = 17590126;
+  optional bool proxy_bind = 286025582;
 
   // Specifies the QUIC override policy for this TargetHttpsProxy resource. This setting determines whether the load balancer attempts to negotiate QUIC with clients. You can specify NONE, ENABLE, or DISABLE.
   // - When quic-override is set to NONE, Google manages whether QUIC is used.
@@ -12235,38 +12235,38 @@ message TargetHttpsProxy {
   // - When quic-override is set to DISABLE, the load balancer doesn't use QUIC.
   // - If the quic-override flag is not specified, NONE is implied.
   // -
-  optional QuicOverride quic_override = 188141741;
+  optional QuicOverride quic_override = 456577197;
 
   // [Output Only] URL of the region where the regional TargetHttpsProxy resides. This field is not applicable to global TargetHttpsProxies.
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // Optional. A URL referring to a networksecurity.ServerTlsPolicy resource that describes how the proxy should authenticate inbound traffic.
   // serverTlsPolicy only applies to a global TargetHttpsProxy attached to globalForwardingRules with the loadBalancingScheme set to INTERNAL_SELF_MANAGED.
   // If left blank, communications are not encrypted.
   // Note: This field currently has no impact.
-  optional string server_tls_policy = 27389810;
+  optional string server_tls_policy = 295825266;
 
   // URLs to SslCertificate resources that are used to authenticate connections between users and the load balancer. At least one SSL certificate must be specified. Currently, you may specify up to 15 SSL certificates.
-  repeated string ssl_certificates = 97571087;
+  repeated string ssl_certificates = 366006543;
 
   // URL of SslPolicy resource that will be associated with the TargetHttpsProxy resource. If not set, the TargetHttpsProxy resource has no SSL policy configured.
-  optional string ssl_policy = 26754757;
+  optional string ssl_policy = 295190213;
 
   // A fully-qualified or valid partial URL to the UrlMap resource that defines the mapping from URL to the BackendService. For example, the following are all valid URLs for specifying a URL map:
   // - https://www.googleapis.compute/v1/projects/project/global/urlMaps/url-map
   // - projects/project/global/urlMaps/url-map
   // - global/urlMaps/url-map
-  optional string url_map = 98585228;
+  optional string url_map = 367020684;
 
 }
 
 //
 message TargetHttpsProxiesScopedList {
   // A list of TargetHttpsProxies contained in this scope.
-  repeated TargetHttpsProxy target_https_proxies = 98172426;
+  repeated TargetHttpsProxy target_https_proxies = 366607882;
 
   // Informational warning which replaces the list of backend services when the list is empty.
   optional Warning warning = 50704284;
@@ -12282,21 +12282,21 @@ message TargetHttpsProxiesSetQuicOverrideRequest {
 
     DISABLE = 241807048;
 
-    ENABLE = 170400131;
+    ENABLE = 438835587;
 
     NONE = 2402104;
 
   }
 
   // QUIC policy for the TargetHttpsProxy resource.
-  optional QuicOverride quic_override = 188141741;
+  optional QuicOverride quic_override = 456577197;
 
 }
 
 //
 message TargetHttpsProxiesSetSslCertificatesRequest {
   // New set of SslCertificate resources to associate with this TargetHttpsProxy resource. Currently exactly one SslCertificate resource must be specified.
-  repeated string ssl_certificates = 97571087;
+  repeated string ssl_certificates = 366006543;
 
 }
 
@@ -12315,7 +12315,7 @@ message TargetHttpsProxyAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -12340,7 +12340,7 @@ message TargetHttpsProxyList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -12364,7 +12364,7 @@ message TargetInstance {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -12382,10 +12382,10 @@ message TargetInstance {
   optional string name = 3373707;
 
   // NAT option controlling how IPs are NAT'ed to the instance. Currently only NO_NAT (default value) is supported.
-  optional NatPolicy nat_policy = 241345040;
+  optional NatPolicy nat_policy = 509780496;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] URL of the zone where the target instance resides. You must specify this field as part of the HTTP request URL. It is not settable as a field in the request body.
   optional string zone = 3744684;
@@ -12395,7 +12395,7 @@ message TargetInstance {
 //
 message TargetInstancesScopedList {
   // A list of target instances contained in this scope.
-  repeated TargetInstance target_instances = 124479824;
+  repeated TargetInstance target_instances = 392915280;
 
   // Informational warning which replaces the list of addresses when the list is empty.
   optional Warning warning = 50704284;
@@ -12417,7 +12417,7 @@ message TargetInstanceAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -12442,7 +12442,7 @@ message TargetInstanceList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -12461,17 +12461,17 @@ message TargetPool {
     // A value indicating that the enum field is not set.
     UNDEFINED_SESSION_AFFINITY = 0;
 
-    CLIENT_IP = 77229595;
+    CLIENT_IP = 345665051;
 
     CLIENT_IP_PORT_PROTO = 221722926;
 
     CLIENT_IP_PROTO = 25322148;
 
-    GENERATED_COOKIE = 101885748;
+    GENERATED_COOKIE = 370321204;
 
     HEADER_FIELD = 200737960;
 
-    HTTP_COOKIE = 226546171;
+    HTTP_COOKIE = 494981627;
 
     NONE = 2402104;
 
@@ -12488,7 +12488,7 @@ message TargetPool {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // This field is applicable only when the containing target pool is serving a forwarding rule as the primary pool (i.e., not as a backup pool to some other target pool). The value of the field must be in [0, 1].
   //
@@ -12498,7 +12498,7 @@ message TargetPool {
   optional float failover_ratio = 212667006;
 
   // The URL of the HttpHealthCheck resource. A member instance in this pool is considered healthy if and only if the health checks pass. An empty list means all member instances will be considered healthy at all times. Only legacy HttpHealthChecks are supported. Only one health check may be specified.
-  repeated string health_checks = 179935150;
+  repeated string health_checks = 448370606;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -12516,20 +12516,20 @@ message TargetPool {
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // Session affinity option, must be one of the following values:
   // NONE: Connections from the same client IP may go to any instance in the pool.
   // CLIENT_IP: Connections from the same client IP will go to the same instance in the pool while that instance remains healthy.
   // CLIENT_IP_PROTO: Connections from the same client IP with the same IP protocol will go to the same instance in the pool while that instance remains healthy.
-  optional SessionAffinity session_affinity = 195453105;
+  optional SessionAffinity session_affinity = 463888561;
 
 }
 
 //
 message TargetPoolsScopedList {
   // A list of target pools contained in this scope.
-  repeated TargetPool target_pools = 67637161;
+  repeated TargetPool target_pools = 336072617;
 
   // Informational warning which replaces the list of addresses when the list is empty.
   optional Warning warning = 50704284;
@@ -12551,7 +12551,7 @@ message TargetPoolAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -12563,7 +12563,7 @@ message TargetPoolAggregatedList {
 
 //
 message TargetPoolInstanceHealth {
-  repeated HealthStatus health_status = 112110389;
+  repeated HealthStatus health_status = 380545845;
 
   // [Output Only] Type of resource. Always compute#targetPoolInstanceHealth when checking the health of an instance.
   optional string kind = 3292052;
@@ -12585,7 +12585,7 @@ message TargetPoolList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -12595,7 +12595,7 @@ message TargetPoolList {
 //
 message TargetPoolsAddHealthCheckRequest {
   // The HttpHealthCheck to add to the target pool.
-  repeated HealthCheckReference health_checks = 179935150;
+  repeated HealthCheckReference health_checks = 448370606;
 
 }
 
@@ -12615,7 +12615,7 @@ message TargetPoolsRemoveHealthCheckRequest {
   // - https://www.googleapis.com/compute/beta/projects/project/global/httpHealthChecks/health-check
   // - projects/project/global/httpHealthChecks/health-check
   // - global/httpHealthChecks/health-check
-  repeated HealthCheckReference health_checks = 179935150;
+  repeated HealthCheckReference health_checks = 448370606;
 
 }
 
@@ -12635,7 +12635,7 @@ message TargetReference {
 //
 message TargetSslProxiesSetBackendServiceRequest {
   // The URL of the new BackendService resource for the targetSslProxy.
-  optional string service = 105105077;
+  optional string service = 373540533;
 
 }
 
@@ -12648,7 +12648,7 @@ message TargetSslProxiesSetProxyHeaderRequest {
 
     NONE = 2402104;
 
-    PROXY_V1 = 65917484;
+    PROXY_V1 = 334352940;
 
   }
 
@@ -12660,7 +12660,7 @@ message TargetSslProxiesSetProxyHeaderRequest {
 //
 message TargetSslProxiesSetSslCertificatesRequest {
   // New set of URLs to SslCertificate resources to associate with this TargetSslProxy. Currently exactly one ssl certificate must be specified.
-  repeated string ssl_certificates = 97571087;
+  repeated string ssl_certificates = 366006543;
 
 }
 
@@ -12675,7 +12675,7 @@ message TargetSslProxy {
 
     NONE = 2402104;
 
-    PROXY_V1 = 65917484;
+    PROXY_V1 = 334352940;
 
   }
 
@@ -12683,7 +12683,7 @@ message TargetSslProxy {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -12698,16 +12698,16 @@ message TargetSslProxy {
   optional ProxyHeader proxy_header = 160374142;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // URL to the BackendService resource.
-  optional string service = 105105077;
+  optional string service = 373540533;
 
   // URLs to SslCertificate resources that are used to authenticate connections to Backends. At least one SSL certificate must be specified. Currently, you may specify up to 15 SSL certificates.
-  repeated string ssl_certificates = 97571087;
+  repeated string ssl_certificates = 366006543;
 
   // URL of SslPolicy resource that will be associated with the TargetSslProxy resource. If not set, the TargetSslProxy resource will not have any SSL policy configured.
-  optional string ssl_policy = 26754757;
+  optional string ssl_policy = 295190213;
 
 }
 
@@ -12726,7 +12726,7 @@ message TargetSslProxyList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -12736,7 +12736,7 @@ message TargetSslProxyList {
 //
 message TargetTcpProxiesSetBackendServiceRequest {
   // The URL of the new BackendService resource for the targetTcpProxy.
-  optional string service = 105105077;
+  optional string service = 373540533;
 
 }
 
@@ -12749,7 +12749,7 @@ message TargetTcpProxiesSetProxyHeaderRequest {
 
     NONE = 2402104;
 
-    PROXY_V1 = 65917484;
+    PROXY_V1 = 334352940;
 
   }
 
@@ -12769,7 +12769,7 @@ message TargetTcpProxy {
 
     NONE = 2402104;
 
-    PROXY_V1 = 65917484;
+    PROXY_V1 = 334352940;
 
   }
 
@@ -12777,7 +12777,7 @@ message TargetTcpProxy {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -12792,10 +12792,10 @@ message TargetTcpProxy {
   optional ProxyHeader proxy_header = 160374142;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // URL to the BackendService resource.
-  optional string service = 105105077;
+  optional string service = 373540533;
 
 }
 
@@ -12814,7 +12814,7 @@ message TargetTcpProxyList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -12830,11 +12830,11 @@ message TargetVpnGateway {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    CREATING = 187129529;
+    CREATING = 455564985;
 
-    DELETING = 260166568;
+    DELETING = 528602024;
 
-    FAILED = 187271229;
+    FAILED = 455706685;
 
     READY = 77848963;
 
@@ -12844,10 +12844,10 @@ message TargetVpnGateway {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] A list of URLs to the ForwardingRule resources. ForwardingRules are created using compute.forwardingRules.insert and associated with a VPN gateway.
-  repeated string forwarding_rules = 47385909;
+  repeated string forwarding_rules = 315821365;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -12865,7 +12865,7 @@ message TargetVpnGateway {
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The status of the VPN gateway, which can be one of the following: CREATING, READY, FAILED, or DELETING.
   optional Status status = 181260274;
@@ -12878,7 +12878,7 @@ message TargetVpnGateway {
 //
 message TargetVpnGatewaysScopedList {
   // [Output Only] A list of target VPN gateways contained in this scope.
-  repeated TargetVpnGateway target_vpn_gateways = 133335432;
+  repeated TargetVpnGateway target_vpn_gateways = 401770888;
 
   // [Output Only] Informational warning which replaces the list of addresses when the list is empty.
   optional Warning warning = 50704284;
@@ -12900,7 +12900,7 @@ message TargetVpnGatewayAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -12925,7 +12925,7 @@ message TargetVpnGatewayList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -12935,7 +12935,7 @@ message TargetVpnGatewayList {
 //
 message TestFailure {
   // BackendService or BackendBucket returned by load balancer.
-  optional string actual_service = 171944196;
+  optional string actual_service = 440379652;
 
   // Expected BackendService or BackendBucket resource the given URL should be mapped to.
   optional string expected_service = 133987374;
@@ -12965,7 +12965,7 @@ message TestPermissionsResponse {
 // Message for the expected URL mappings.
 message UrlMapTest {
   // Description of this test case.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // Host portion of the URL. If headers contains a host header, then host must also match the header value.
   optional string host = 3208616;
@@ -12975,7 +12975,7 @@ message UrlMapTest {
 
   // Expected BackendService or BackendBucket resource the given URL should be mapped to.
   // service cannot be set if expectedRedirectResponseCode is set.
-  optional string service = 105105077;
+  optional string service = 373540533;
 
 }
 
@@ -12994,7 +12994,7 @@ message UrlMapList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -13003,18 +13003,18 @@ message UrlMapList {
 
 //
 message UrlMapReference {
-  optional string url_map = 98585228;
+  optional string url_map = 367020684;
 
 }
 
 // Message representing the validation result for a UrlMap.
 message UrlMapValidationResult {
-  repeated string load_errors = 41711844;
+  repeated string load_errors = 310147300;
 
   // Whether the given UrlMap can be successfully loaded. If false, 'loadErrors' indicates the reasons.
   optional bool load_succeeded = 128326216;
 
-  repeated TestFailure test_failures = 237498678;
+  repeated TestFailure test_failures = 505934134;
 
   // If successfully loaded, this field indicates whether the test passed. If false, 'testFailures's indicate the reason of failure.
   optional bool test_passed = 192708797;
@@ -13046,7 +13046,7 @@ message UrlMapsAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -13075,7 +13075,7 @@ message UsableSubnetworkSecondaryRange {
   optional string ip_cidr_range = 98117322;
 
   // The name associated with this subnetwork secondary range, used when adding an alias IP range to a VM instance. The name must be 1-63 characters long, and comply with RFC1035. The name must be unique within the subnetwork.
-  optional string range_name = 63780941;
+  optional string range_name = 332216397;
 
 }
 
@@ -13091,7 +13091,7 @@ message UsableSubnetwork {
   repeated UsableSubnetworkSecondaryRange secondary_ip_ranges = 136658915;
 
   // Subnetwork URL.
-  optional string subnetwork = 39392238;
+  optional string subnetwork = 307827694;
 
 }
 
@@ -13110,7 +13110,7 @@ message UsableSubnetworksAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -13120,19 +13120,19 @@ message UsableSubnetworksAggregatedList {
 // Contain information of Nat mapping for an interface of this endpoint.
 message VmEndpointNatMappingsInterfaceNatMappings {
   // List of all drain IP:port-range mappings assigned to this interface. These ranges are inclusive, that is, both the first and the last ports can be used for NAT. Example: ["2.2.2.2:12345-12355", "1.1.1.1:2234-2234"].
-  repeated string drain_nat_ip_port_ranges = 127005121;
+  repeated string drain_nat_ip_port_ranges = 395440577;
 
   // A list of all IP:port-range mappings assigned to this interface. These ranges are inclusive, that is, both the first and the last ports can be used for NAT. Example: ["2.2.2.2:12345-12355", "1.1.1.1:2234-2234"].
-  repeated string nat_ip_port_ranges = 263395354;
+  repeated string nat_ip_port_ranges = 531830810;
 
   // Total number of drain ports across all NAT IPs allocated to this interface. It equals to the aggregated port number in the field drain_nat_ip_port_ranges.
-  optional int32 num_total_drain_nat_ports = 67097337;
+  optional int32 num_total_drain_nat_ports = 335532793;
 
   // Total number of ports across all NAT IPs allocated to this interface. It equals to the aggregated port number in the field nat_ip_port_ranges.
-  optional int32 num_total_nat_ports = 31468928;
+  optional int32 num_total_nat_ports = 299904384;
 
   // Alias IP range for this interface endpoint. It will be a private (RFC 1918) IP range. Examples: "10.33.4.55/32", or "192.168.5.0/24".
-  optional string source_alias_ip_range = 171905496;
+  optional string source_alias_ip_range = 440340952;
 
   // Primary IP of the VM for this NIC.
   optional string source_virtual_ip = 149836159;
@@ -13163,7 +13163,7 @@ message VmEndpointNatMappingsList {
   repeated VmEndpointNatMappings result = 139315229;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -13176,7 +13176,7 @@ message VpnGatewayVpnGatewayInterface {
   optional uint32 id = 3355;
 
   // [Output Only] The external IP address for this VPN gateway interface.
-  optional string ip_address = 137836764;
+  optional string ip_address = 406272220;
 
 }
 
@@ -13188,7 +13188,7 @@ message VpnGateway {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -13202,7 +13202,7 @@ message VpnGateway {
   optional string label_fingerprint = 178124825;
 
   // Labels for this resource. These can only be added or modified by the setLabels method. Each label key/value pair must comply with RFC1035. Label values may be empty.
-  map<string, string> labels = 231759871;
+  map<string, string> labels = 500195327;
 
   // Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
   optional string name = 3373707;
@@ -13214,7 +13214,7 @@ message VpnGateway {
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // A list of interfaces on this VPN gateway.
   repeated VpnGatewayVpnGatewayInterface vpn_interfaces = 91842181;
@@ -13246,7 +13246,7 @@ message VpnGatewayAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -13271,7 +13271,7 @@ message VpnGatewayList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -13281,10 +13281,10 @@ message VpnGatewayList {
 // A VPN connection contains all VPN tunnels connected from this VpnGateway to the same peer gateway. The peer gateway could either be a external VPN gateway or GCP VPN gateway.
 message VpnGatewayStatusVpnConnection {
   // URL reference to the peer external VPN gateways to which the VPN tunnels in this VPN connection are connected. This field is mutually exclusive with peer_gcp_gateway.
-  optional string peer_external_gateway = 116520717;
+  optional string peer_external_gateway = 384956173;
 
   // URL reference to the peer side VPN gateways to which the VPN tunnels in this VPN connection are connected. This field is mutually exclusive with peer_gcp_gateway.
-  optional string peer_gcp_gateway = 13431996;
+  optional string peer_gcp_gateway = 281867452;
 
   // HighAvailabilityRequirementState for the VPN connection.
   optional VpnGatewayStatusHighAvailabilityRequirementState state = 109757585;
@@ -13297,7 +13297,7 @@ message VpnGatewayStatusVpnConnection {
 //
 message VpnGatewayStatus {
   // List of VPN connection for this VpnGateway.
-  repeated VpnGatewayStatusVpnConnection vpn_connections = 170899082;
+  repeated VpnGatewayStatusVpnConnection vpn_connections = 439334538;
 
 }
 
@@ -13308,9 +13308,9 @@ message VpnGatewayStatusHighAvailabilityRequirementState {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATE = 0;
 
-    CONNECTION_REDUNDANCY_MET = 236807451;
+    CONNECTION_REDUNDANCY_MET = 505242907;
 
-    CONNECTION_REDUNDANCY_NOT_MET = 243427855;
+    CONNECTION_REDUNDANCY_NOT_MET = 511863311;
 
   }
 
@@ -13374,29 +13374,29 @@ message VpnTunnel {
     // A value indicating that the enum field is not set.
     UNDEFINED_STATUS = 0;
 
-    ALLOCATING_RESOURCES = 52487360;
+    ALLOCATING_RESOURCES = 320922816;
 
     AUTHORIZATION_ERROR = 23580290;
 
-    DEPROVISIONING = 160500206;
+    DEPROVISIONING = 428935662;
 
     ESTABLISHED = 88852344;
 
-    FAILED = 187271229;
+    FAILED = 455706685;
 
     FIRST_HANDSHAKE = 191393000;
 
-    NEGOTIATION_FAILURE = 91890412;
+    NEGOTIATION_FAILURE = 360325868;
 
     NETWORK_ERROR = 193912951;
 
     NO_INCOMING_PACKETS = 119983216;
 
-    PROVISIONING = 22461165;
+    PROVISIONING = 290896621;
 
     REJECTED = 174130302;
 
-    STOPPED = 175840685;
+    STOPPED = 444276141;
 
     WAITING_FOR_FULL_CONFIG = 41640522;
 
@@ -13406,10 +13406,10 @@ message VpnTunnel {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this property when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] Detailed status message for the VPN tunnel.
-  optional string detailed_status = 65065569;
+  optional string detailed_status = 333501025;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -13421,40 +13421,40 @@ message VpnTunnel {
   optional string kind = 3292052;
 
   // Local traffic selector to use when establishing the VPN tunnel with the peer VPN gateway. The value should be a CIDR formatted string, for example: 192.168.0.0/16. The ranges must be disjoint. Only IPv4 is supported.
-  repeated string local_traffic_selector = 48879157;
+  repeated string local_traffic_selector = 317314613;
 
   // Name of the resource. Provided by the client when the resource is created. The name must be 1-63 characters long, and comply with RFC1035. Specifically, the name must be 1-63 characters long and match the regular expression `[a-z]([-a-z0-9]*[a-z0-9])?` which means the first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash.
   optional string name = 3373707;
 
   // URL of the peer side external VPN gateway to which this VPN tunnel is connected. Provided by the client when the VPN tunnel is created. This field is exclusive with the field peerGcpGateway.
-  optional string peer_external_gateway = 116520717;
+  optional string peer_external_gateway = 384956173;
 
   // The interface ID of the external VPN gateway to which this VPN tunnel is connected. Provided by the client when the VPN tunnel is created.
-  optional int32 peer_external_gateway_interface = 184332935;
+  optional int32 peer_external_gateway_interface = 452768391;
 
   // URL of the peer side HA GCP VPN gateway to which this VPN tunnel is connected. Provided by the client when the VPN tunnel is created. This field can be used when creating highly available VPN from VPC network to VPC network, the field is exclusive with the field peerExternalGateway. If provided, the VPN tunnel will automatically use the same vpnGatewayInterface ID in the peer GCP VPN gateway.
-  optional string peer_gcp_gateway = 13431996;
+  optional string peer_gcp_gateway = 281867452;
 
   // IP address of the peer VPN gateway. Only IPv4 is supported.
-  optional string peer_ip = 114814244;
+  optional string peer_ip = 383249700;
 
   // [Output Only] URL of the region where the VPN tunnel resides. You must specify this field as part of the HTTP request URL. It is not settable as a field in the request body.
   optional string region = 138946292;
 
   // Remote traffic selectors to use when establishing the VPN tunnel with the peer VPN gateway. The value should be a CIDR formatted string, for example: 192.168.0.0/16. The ranges should be disjoint. Only IPv4 is supported.
-  repeated string remote_traffic_selector = 90451642;
+  repeated string remote_traffic_selector = 358887098;
 
   // URL of the router resource to be used for dynamic routing.
   optional string router = 148608841;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // Shared secret used to set the secure session between the Cloud VPN gateway and the peer VPN gateway.
-  optional string shared_secret = 113497034;
+  optional string shared_secret = 381932490;
 
   // Hash of the shared secret.
-  optional string shared_secret_hash = 130446435;
+  optional string shared_secret_hash = 398881891;
 
   // [Output Only] The status of the VPN tunnel, which can be one of the following:
   // - PROVISIONING: Resource is being allocated for the VPN tunnel.
@@ -13475,10 +13475,10 @@ message VpnTunnel {
   optional Status status = 181260274;
 
   // URL of the Target VPN gateway with which this VPN tunnel is associated. Provided by the client when the VPN tunnel is created.
-  optional string target_vpn_gateway = 264077387;
+  optional string target_vpn_gateway = 532512843;
 
   // URL of the VPN gateway with which this VPN tunnel is associated. Provided by the client when the VPN tunnel is created. This must be used (instead of target_vpn_gateway) if a High Availability VPN gateway resource is created.
-  optional string vpn_gateway = 138248697;
+  optional string vpn_gateway = 406684153;
 
   // The interface ID of the VPN gateway with which this VPN tunnel is associated.
   optional int32 vpn_gateway_interface = 95979123;
@@ -13510,7 +13510,7 @@ message VpnTunnelAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Unreachable resources.
   repeated string unreachables = 243372063;
@@ -13535,7 +13535,7 @@ message VpnTunnelList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -13564,7 +13564,7 @@ message XpnHostList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -13593,10 +13593,10 @@ message Zone {
   optional string creation_timestamp = 30525366;
 
   // [Output Only] The deprecation status associated with this zone.
-  optional DeprecationStatus deprecated = 246703539;
+  optional DeprecationStatus deprecated = 515138995;
 
   // [Output Only] Textual description of the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
@@ -13611,7 +13611,7 @@ message Zone {
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Status of the zone, either UP or DOWN.
   optional Status status = 181260274;
@@ -13633,7 +13633,7 @@ message ZoneList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -13646,14 +13646,14 @@ message ZoneSetLabelsRequest {
   optional string label_fingerprint = 178124825;
 
   // The labels to set for this resource.
-  map<string, string> labels = 231759871;
+  map<string, string> labels = 500195327;
 
 }
 
 //
 message ZoneSetPolicyRequest {
   // Flatten Policy to create a backwacd compatible wire-format. Deprecated. Use 'policy' to specify bindings.
-  repeated Binding bindings = 134816398;
+  repeated Binding bindings = 403251854;
 
   // Flatten Policy to create a backward compatible wire-format. Deprecated. Use 'policy' to specify the etag.
   optional string etag = 3123477;
@@ -13672,10 +13672,10 @@ message AggregatedListAcceleratorTypesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -13694,7 +13694,7 @@ message AggregatedListAcceleratorTypesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -13720,7 +13720,7 @@ message ListAcceleratorTypesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -13739,7 +13739,7 @@ message ListAcceleratorTypesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -13755,10 +13755,10 @@ message AggregatedListAddressesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -13777,14 +13777,14 @@ message AggregatedListAddressesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for Addresses.Delete. See the method description for details.
 message DeleteAddressRequest {
   // Name of the address resource to delete.
-  string address = 194485236 [(google.api.field_behavior) = REQUIRED];
+  string address = 462920692 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -13804,7 +13804,7 @@ message DeleteAddressRequest {
 // A request message for Addresses.Get. See the method description for details.
 message GetAddressRequest {
   // Name of the address resource to return.
-  string address = 194485236 [(google.api.field_behavior) = REQUIRED];
+  string address = 462920692 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -13817,7 +13817,7 @@ message GetAddressRequest {
 // A request message for Addresses.Insert. See the method description for details.
 message InsertAddressRequest {
   // The body resource for this request
-  Address address_resource = 215452665 [(google.api.field_behavior) = REQUIRED];
+  Address address_resource = 483888121 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -13843,7 +13843,7 @@ message ListAddressesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -13865,7 +13865,7 @@ message ListAddressesRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -13878,10 +13878,10 @@ message AggregatedListAutoscalersRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -13900,14 +13900,14 @@ message AggregatedListAutoscalersRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for Autoscalers.Delete. See the method description for details.
 message DeleteAutoscalerRequest {
   // Name of the autoscaler to delete.
-  string autoscaler = 248823511 [(google.api.field_behavior) = REQUIRED];
+  string autoscaler = 517258967 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -13927,7 +13927,7 @@ message DeleteAutoscalerRequest {
 // A request message for Autoscalers.Get. See the method description for details.
 message GetAutoscalerRequest {
   // Name of the autoscaler to return.
-  string autoscaler = 248823511 [(google.api.field_behavior) = REQUIRED];
+  string autoscaler = 517258967 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -13966,7 +13966,7 @@ message ListAutoscalersRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -13985,7 +13985,7 @@ message ListAutoscalersRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // Name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -13995,7 +13995,7 @@ message ListAutoscalersRequest {
 // A request message for Autoscalers.Patch. See the method description for details.
 message PatchAutoscalerRequest {
   // Name of the autoscaler to patch.
-  optional string autoscaler = 248823511;
+  optional string autoscaler = 517258967;
 
   // The body resource for this request
   Autoscaler autoscaler_resource = 207616118 [(google.api.field_behavior) = REQUIRED];
@@ -14018,7 +14018,7 @@ message PatchAutoscalerRequest {
 // A request message for Autoscalers.Update. See the method description for details.
 message UpdateAutoscalerRequest {
   // Name of the autoscaler to update.
-  optional string autoscaler = 248823511;
+  optional string autoscaler = 517258967;
 
   // The body resource for this request
   Autoscaler autoscaler_resource = 207616118 [(google.api.field_behavior) = REQUIRED];
@@ -14054,7 +14054,7 @@ message AddSignedUrlKeyBackendBucketRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  SignedUrlKey signed_url_key_resource = 189190529 [(google.api.field_behavior) = REQUIRED];
+  SignedUrlKey signed_url_key_resource = 457625985 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -14081,7 +14081,7 @@ message DeleteSignedUrlKeyBackendBucketRequest {
   string backend_bucket = 91714037 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the Signed URL Key to delete.
-  string key_name = 232503403 [(google.api.field_behavior) = REQUIRED];
+  string key_name = 500938859 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14108,7 +14108,7 @@ message GetBackendBucketRequest {
 // A request message for BackendBuckets.Insert. See the method description for details.
 message InsertBackendBucketRequest {
   // The body resource for this request
-  BackendBucket backend_bucket_resource = 112322328 [(google.api.field_behavior) = REQUIRED];
+  BackendBucket backend_bucket_resource = 380757784 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14131,7 +14131,7 @@ message ListBackendBucketsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -14150,7 +14150,7 @@ message ListBackendBucketsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -14160,7 +14160,7 @@ message PatchBackendBucketRequest {
   string backend_bucket = 91714037 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  BackendBucket backend_bucket_resource = 112322328 [(google.api.field_behavior) = REQUIRED];
+  BackendBucket backend_bucket_resource = 380757784 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14180,7 +14180,7 @@ message UpdateBackendBucketRequest {
   string backend_bucket = 91714037 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  BackendBucket backend_bucket_resource = 112322328 [(google.api.field_behavior) = REQUIRED];
+  BackendBucket backend_bucket_resource = 380757784 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14197,7 +14197,7 @@ message UpdateBackendBucketRequest {
 // A request message for BackendServices.AddSignedUrlKey. See the method description for details.
 message AddSignedUrlKeyBackendServiceRequest {
   // Name of the BackendService resource to which the Signed URL Key should be added. The name should conform to RFC1035.
-  string backend_service = 38510602 [(google.api.field_behavior) = REQUIRED];
+  string backend_service = 306946058 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14210,7 +14210,7 @@ message AddSignedUrlKeyBackendServiceRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  SignedUrlKey signed_url_key_resource = 189190529 [(google.api.field_behavior) = REQUIRED];
+  SignedUrlKey signed_url_key_resource = 457625985 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -14223,10 +14223,10 @@ message AggregatedListBackendServicesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -14245,14 +14245,14 @@ message AggregatedListBackendServicesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for BackendServices.Delete. See the method description for details.
 message DeleteBackendServiceRequest {
   // Name of the BackendService resource to delete.
-  string backend_service = 38510602 [(google.api.field_behavior) = REQUIRED];
+  string backend_service = 306946058 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14269,10 +14269,10 @@ message DeleteBackendServiceRequest {
 // A request message for BackendServices.DeleteSignedUrlKey. See the method description for details.
 message DeleteSignedUrlKeyBackendServiceRequest {
   // Name of the BackendService resource to which the Signed URL Key should be added. The name should conform to RFC1035.
-  string backend_service = 38510602 [(google.api.field_behavior) = REQUIRED];
+  string backend_service = 306946058 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the Signed URL Key to delete.
-  string key_name = 232503403 [(google.api.field_behavior) = REQUIRED];
+  string key_name = 500938859 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14289,7 +14289,7 @@ message DeleteSignedUrlKeyBackendServiceRequest {
 // A request message for BackendServices.Get. See the method description for details.
 message GetBackendServiceRequest {
   // Name of the BackendService resource to return.
-  string backend_service = 38510602 [(google.api.field_behavior) = REQUIRED];
+  string backend_service = 306946058 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14299,7 +14299,7 @@ message GetBackendServiceRequest {
 // A request message for BackendServices.GetHealth. See the method description for details.
 message GetHealthBackendServiceRequest {
   // Name of the BackendService resource to which the queried instance belongs.
-  string backend_service = 38510602 [(google.api.field_behavior) = REQUIRED];
+  string backend_service = 306946058 [(google.api.field_behavior) = REQUIRED];
 
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
@@ -14311,7 +14311,7 @@ message GetHealthBackendServiceRequest {
 // A request message for BackendServices.Insert. See the method description for details.
 message InsertBackendServiceRequest {
   // The body resource for this request
-  BackendService backend_service_resource = 79151267 [(google.api.field_behavior) = REQUIRED];
+  BackendService backend_service_resource = 347586723 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14334,7 +14334,7 @@ message ListBackendServicesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -14353,17 +14353,17 @@ message ListBackendServicesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for BackendServices.Patch. See the method description for details.
 message PatchBackendServiceRequest {
   // Name of the BackendService resource to patch.
-  string backend_service = 38510602 [(google.api.field_behavior) = REQUIRED];
+  string backend_service = 306946058 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  BackendService backend_service_resource = 79151267 [(google.api.field_behavior) = REQUIRED];
+  BackendService backend_service_resource = 347586723 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14380,7 +14380,7 @@ message PatchBackendServiceRequest {
 // A request message for BackendServices.SetSecurityPolicy. See the method description for details.
 message SetSecurityPolicyBackendServiceRequest {
   // Name of the BackendService resource to which the security policy should be set. The name should conform to RFC1035.
-  string backend_service = 38510602 [(google.api.field_behavior) = REQUIRED];
+  string backend_service = 306946058 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14400,10 +14400,10 @@ message SetSecurityPolicyBackendServiceRequest {
 // A request message for BackendServices.Update. See the method description for details.
 message UpdateBackendServiceRequest {
   // Name of the BackendService resource to update.
-  string backend_service = 38510602 [(google.api.field_behavior) = REQUIRED];
+  string backend_service = 306946058 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  BackendService backend_service_resource = 79151267 [(google.api.field_behavior) = REQUIRED];
+  BackendService backend_service_resource = 347586723 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14426,10 +14426,10 @@ message AggregatedListDiskTypesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -14448,7 +14448,7 @@ message AggregatedListDiskTypesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -14474,7 +14474,7 @@ message ListDiskTypesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -14493,7 +14493,7 @@ message ListDiskTypesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -14506,7 +14506,7 @@ message AddResourcePoliciesDiskRequest {
   string disk = 3083677 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  DisksAddResourcePoliciesRequest disks_add_resource_policies_request_resource = 228047907 [(google.api.field_behavior) = REQUIRED];
+  DisksAddResourcePoliciesRequest disks_add_resource_policies_request_resource = 496483363 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14532,10 +14532,10 @@ message AggregatedListDisksRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -14554,7 +14554,7 @@ message AggregatedListDisksRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -14564,7 +14564,7 @@ message CreateSnapshotDiskRequest {
   string disk = 3083677 [(google.api.field_behavior) = REQUIRED];
 
   // [Input Only] Whether to attempt an application consistent snapshot by informing the OS to prepare for the snapshot process. Currently only supported on Windows instances using the Volume Shadow Copy Service (VSS).
-  optional bool guest_flush = 117115357;
+  optional bool guest_flush = 385550813;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14577,7 +14577,7 @@ message CreateSnapshotDiskRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  Snapshot snapshot_resource = 212884521 [(google.api.field_behavior) = REQUIRED];
+  Snapshot snapshot_resource = 481319977 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -14620,7 +14620,7 @@ message GetDiskRequest {
 // A request message for Disks.GetIamPolicy. See the method description for details.
 message GetIamPolicyDiskRequest {
   // Requested IAM Policy version.
-  optional int32 options_requested_policy_version = 230784573;
+  optional int32 options_requested_policy_version = 499220029;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14665,7 +14665,7 @@ message ListDisksRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -14684,7 +14684,7 @@ message ListDisksRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -14697,7 +14697,7 @@ message RemoveResourcePoliciesDiskRequest {
   string disk = 3083677 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  DisksRemoveResourcePoliciesRequest disks_remove_resource_policies_request_resource = 168321262 [(google.api.field_behavior) = REQUIRED];
+  DisksRemoveResourcePoliciesRequest disks_remove_resource_policies_request_resource = 436756718 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14749,7 +14749,7 @@ message SetIamPolicyDiskRequest {
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  ZoneSetPolicyRequest zone_set_policy_request_resource = 113646651 [(google.api.field_behavior) = REQUIRED];
+  ZoneSetPolicyRequest zone_set_policy_request_resource = 382082107 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -14772,7 +14772,7 @@ message SetLabelsDiskRequest {
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  ZoneSetLabelsRequest zone_set_labels_request_resource = 96515342 [(google.api.field_behavior) = REQUIRED];
+  ZoneSetLabelsRequest zone_set_labels_request_resource = 364950798 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -14785,7 +14785,7 @@ message TestIamPermissionsDiskRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -14822,7 +14822,7 @@ message GetExternalVpnGatewayRequest {
 // A request message for ExternalVpnGateways.Insert. See the method description for details.
 message InsertExternalVpnGatewayRequest {
   // The body resource for this request
-  ExternalVpnGateway external_vpn_gateway_resource = 218378120 [(google.api.field_behavior) = REQUIRED];
+  ExternalVpnGateway external_vpn_gateway_resource = 486813576 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14845,7 +14845,7 @@ message ListExternalVpnGatewaysRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -14864,14 +14864,14 @@ message ListExternalVpnGatewaysRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for ExternalVpnGateways.SetLabels. See the method description for details.
 message SetLabelsExternalVpnGatewayRequest {
   // The body resource for this request
-  GlobalSetLabelsRequest global_set_labels_request_resource = 51481733 [(google.api.field_behavior) = REQUIRED];
+  GlobalSetLabelsRequest global_set_labels_request_resource = 319917189 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14890,14 +14890,14 @@ message TestIamPermissionsExternalVpnGatewayRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
 }
 
 // A request message for Firewalls.Delete. See the method description for details.
 message DeleteFirewallRequest {
   // Name of the firewall rule to delete.
-  string firewall = 242580736 [(google.api.field_behavior) = REQUIRED];
+  string firewall = 511016192 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14914,7 +14914,7 @@ message DeleteFirewallRequest {
 // A request message for Firewalls.Get. See the method description for details.
 message GetFirewallRequest {
   // Name of the firewall rule to return.
-  string firewall = 242580736 [(google.api.field_behavior) = REQUIRED];
+  string firewall = 511016192 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -14947,7 +14947,7 @@ message ListFirewallsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -14966,14 +14966,14 @@ message ListFirewallsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for Firewalls.Patch. See the method description for details.
 message PatchFirewallRequest {
   // Name of the firewall rule to patch.
-  string firewall = 242580736 [(google.api.field_behavior) = REQUIRED];
+  string firewall = 511016192 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   Firewall firewall_resource = 41425005 [(google.api.field_behavior) = REQUIRED];
@@ -14993,7 +14993,7 @@ message PatchFirewallRequest {
 // A request message for Firewalls.Update. See the method description for details.
 message UpdateFirewallRequest {
   // Name of the firewall rule to update.
-  string firewall = 242580736 [(google.api.field_behavior) = REQUIRED];
+  string firewall = 511016192 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   Firewall firewall_resource = 41425005 [(google.api.field_behavior) = REQUIRED];
@@ -15019,10 +15019,10 @@ message AggregatedListForwardingRulesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -15041,14 +15041,14 @@ message AggregatedListForwardingRulesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for ForwardingRules.Delete. See the method description for details.
 message DeleteForwardingRuleRequest {
   // Name of the ForwardingRule resource to delete.
-  string forwarding_rule = 1528574 [(google.api.field_behavior) = REQUIRED];
+  string forwarding_rule = 269964030 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15068,7 +15068,7 @@ message DeleteForwardingRuleRequest {
 // A request message for ForwardingRules.Get. See the method description for details.
 message GetForwardingRuleRequest {
   // Name of the ForwardingRule resource to return.
-  string forwarding_rule = 1528574 [(google.api.field_behavior) = REQUIRED];
+  string forwarding_rule = 269964030 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15081,7 +15081,7 @@ message GetForwardingRuleRequest {
 // A request message for ForwardingRules.Insert. See the method description for details.
 message InsertForwardingRuleRequest {
   // The body resource for this request
-  ForwardingRule forwarding_rule_resource = 32776239 [(google.api.field_behavior) = REQUIRED];
+  ForwardingRule forwarding_rule_resource = 301211695 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15107,7 +15107,7 @@ message ListForwardingRulesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -15129,17 +15129,17 @@ message ListForwardingRulesRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for ForwardingRules.Patch. See the method description for details.
 message PatchForwardingRuleRequest {
   // Name of the ForwardingRule resource to patch.
-  string forwarding_rule = 1528574 [(google.api.field_behavior) = REQUIRED];
+  string forwarding_rule = 269964030 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  ForwardingRule forwarding_rule_resource = 32776239 [(google.api.field_behavior) = REQUIRED];
+  ForwardingRule forwarding_rule_resource = 301211695 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15159,7 +15159,7 @@ message PatchForwardingRuleRequest {
 // A request message for ForwardingRules.SetTarget. See the method description for details.
 message SetTargetForwardingRuleRequest {
   // Name of the ForwardingRule resource in which target is to be set.
-  string forwarding_rule = 1528574 [(google.api.field_behavior) = REQUIRED];
+  string forwarding_rule = 269964030 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15175,14 +15175,14 @@ message SetTargetForwardingRuleRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  TargetReference target_reference_resource = 255286256 [(google.api.field_behavior) = REQUIRED];
+  TargetReference target_reference_resource = 523721712 [(google.api.field_behavior) = REQUIRED];
 
 }
 
 // A request message for GlobalAddresses.Delete. See the method description for details.
 message DeleteGlobalAddressRequest {
   // Name of the address resource to delete.
-  string address = 194485236 [(google.api.field_behavior) = REQUIRED];
+  string address = 462920692 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15199,7 +15199,7 @@ message DeleteGlobalAddressRequest {
 // A request message for GlobalAddresses.Get. See the method description for details.
 message GetGlobalAddressRequest {
   // Name of the address resource to return.
-  string address = 194485236 [(google.api.field_behavior) = REQUIRED];
+  string address = 462920692 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15209,7 +15209,7 @@ message GetGlobalAddressRequest {
 // A request message for GlobalAddresses.Insert. See the method description for details.
 message InsertGlobalAddressRequest {
   // The body resource for this request
-  Address address_resource = 215452665 [(google.api.field_behavior) = REQUIRED];
+  Address address_resource = 483888121 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15232,7 +15232,7 @@ message ListGlobalAddressesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -15251,14 +15251,14 @@ message ListGlobalAddressesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for GlobalForwardingRules.Delete. See the method description for details.
 message DeleteGlobalForwardingRuleRequest {
   // Name of the ForwardingRule resource to delete.
-  string forwarding_rule = 1528574 [(google.api.field_behavior) = REQUIRED];
+  string forwarding_rule = 269964030 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15275,7 +15275,7 @@ message DeleteGlobalForwardingRuleRequest {
 // A request message for GlobalForwardingRules.Get. See the method description for details.
 message GetGlobalForwardingRuleRequest {
   // Name of the ForwardingRule resource to return.
-  string forwarding_rule = 1528574 [(google.api.field_behavior) = REQUIRED];
+  string forwarding_rule = 269964030 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15285,7 +15285,7 @@ message GetGlobalForwardingRuleRequest {
 // A request message for GlobalForwardingRules.Insert. See the method description for details.
 message InsertGlobalForwardingRuleRequest {
   // The body resource for this request
-  ForwardingRule forwarding_rule_resource = 32776239 [(google.api.field_behavior) = REQUIRED];
+  ForwardingRule forwarding_rule_resource = 301211695 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15308,7 +15308,7 @@ message ListGlobalForwardingRulesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -15327,17 +15327,17 @@ message ListGlobalForwardingRulesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for GlobalForwardingRules.Patch. See the method description for details.
 message PatchGlobalForwardingRuleRequest {
   // Name of the ForwardingRule resource to patch.
-  string forwarding_rule = 1528574 [(google.api.field_behavior) = REQUIRED];
+  string forwarding_rule = 269964030 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  ForwardingRule forwarding_rule_resource = 32776239 [(google.api.field_behavior) = REQUIRED];
+  ForwardingRule forwarding_rule_resource = 301211695 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15354,7 +15354,7 @@ message PatchGlobalForwardingRuleRequest {
 // A request message for GlobalForwardingRules.SetTarget. See the method description for details.
 message SetTargetGlobalForwardingRuleRequest {
   // Name of the ForwardingRule resource in which target is to be set.
-  string forwarding_rule = 1528574 [(google.api.field_behavior) = REQUIRED];
+  string forwarding_rule = 269964030 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15367,7 +15367,7 @@ message SetTargetGlobalForwardingRuleRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  TargetReference target_reference_resource = 255286256 [(google.api.field_behavior) = REQUIRED];
+  TargetReference target_reference_resource = 523721712 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -15377,7 +15377,7 @@ message AttachNetworkEndpointsGlobalNetworkEndpointGroupRequest {
   GlobalNetworkEndpointGroupsAttachEndpointsRequest global_network_endpoint_groups_attach_endpoints_request_resource = 30691563 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the network endpoint group where you are attaching network endpoints to. It should comply with RFC1035.
-  string network_endpoint_group = 165471622 [(google.api.field_behavior) = REQUIRED];
+  string network_endpoint_group = 433907078 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15394,7 +15394,7 @@ message AttachNetworkEndpointsGlobalNetworkEndpointGroupRequest {
 // A request message for GlobalNetworkEndpointGroups.Delete. See the method description for details.
 message DeleteGlobalNetworkEndpointGroupRequest {
   // The name of the network endpoint group to delete. It should comply with RFC1035.
-  string network_endpoint_group = 165471622 [(google.api.field_behavior) = REQUIRED];
+  string network_endpoint_group = 433907078 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15414,7 +15414,7 @@ message DetachNetworkEndpointsGlobalNetworkEndpointGroupRequest {
   GlobalNetworkEndpointGroupsDetachEndpointsRequest global_network_endpoint_groups_detach_endpoints_request_resource = 8898269 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the network endpoint group where you are removing network endpoints. It should comply with RFC1035.
-  string network_endpoint_group = 165471622 [(google.api.field_behavior) = REQUIRED];
+  string network_endpoint_group = 433907078 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15431,7 +15431,7 @@ message DetachNetworkEndpointsGlobalNetworkEndpointGroupRequest {
 // A request message for GlobalNetworkEndpointGroups.Get. See the method description for details.
 message GetGlobalNetworkEndpointGroupRequest {
   // The name of the network endpoint group. It should comply with RFC1035.
-  string network_endpoint_group = 165471622 [(google.api.field_behavior) = REQUIRED];
+  string network_endpoint_group = 433907078 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15441,7 +15441,7 @@ message GetGlobalNetworkEndpointGroupRequest {
 // A request message for GlobalNetworkEndpointGroups.Insert. See the method description for details.
 message InsertGlobalNetworkEndpointGroupRequest {
   // The body resource for this request
-  NetworkEndpointGroup network_endpoint_group_resource = 257353383 [(google.api.field_behavior) = REQUIRED];
+  NetworkEndpointGroup network_endpoint_group_resource = 525788839 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15464,7 +15464,7 @@ message ListGlobalNetworkEndpointGroupsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -15483,7 +15483,7 @@ message ListGlobalNetworkEndpointGroupsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -15496,13 +15496,13 @@ message ListNetworkEndpointsGlobalNetworkEndpointGroupsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
 
   // The name of the network endpoint group from which you want to generate a list of included network endpoints. It should comply with RFC1035.
-  string network_endpoint_group = 165471622 [(google.api.field_behavior) = REQUIRED];
+  string network_endpoint_group = 433907078 [(google.api.field_behavior) = REQUIRED];
 
   // Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.
   //
@@ -15518,7 +15518,7 @@ message ListNetworkEndpointsGlobalNetworkEndpointGroupsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -15531,10 +15531,10 @@ message AggregatedListGlobalOperationsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -15553,7 +15553,7 @@ message AggregatedListGlobalOperationsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -15590,7 +15590,7 @@ message ListGlobalOperationsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -15609,7 +15609,7 @@ message ListGlobalOperationsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -15629,7 +15629,7 @@ message DeleteGlobalOrganizationOperationRequest {
   string operation = 52090215 [(google.api.field_behavior) = REQUIRED];
 
   // Parent ID for this request.
-  optional string parent_id = 191279312;
+  optional string parent_id = 459714768;
 
 }
 
@@ -15643,7 +15643,7 @@ message GetGlobalOrganizationOperationRequest {
   string operation = 52090215 [(google.api.field_behavior) = REQUIRED];
 
   // Parent ID for this request.
-  optional string parent_id = 191279312;
+  optional string parent_id = 459714768;
 
 }
 
@@ -15656,7 +15656,7 @@ message ListGlobalOrganizationOperationsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -15672,10 +15672,10 @@ message ListGlobalOrganizationOperationsRequest {
   optional string page_token = 19994697;
 
   // Parent ID for this request.
-  optional string parent_id = 191279312;
+  optional string parent_id = 459714768;
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -15688,10 +15688,10 @@ message AggregatedListHealthChecksRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -15710,14 +15710,14 @@ message AggregatedListHealthChecksRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for HealthChecks.Delete. See the method description for details.
 message DeleteHealthCheckRequest {
   // Name of the HealthCheck resource to delete.
-  string health_check = 40441189 [(google.api.field_behavior) = REQUIRED];
+  string health_check = 308876645 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15734,7 +15734,7 @@ message DeleteHealthCheckRequest {
 // A request message for HealthChecks.Get. See the method description for details.
 message GetHealthCheckRequest {
   // Name of the HealthCheck resource to return.
-  string health_check = 40441189 [(google.api.field_behavior) = REQUIRED];
+  string health_check = 308876645 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15767,7 +15767,7 @@ message ListHealthChecksRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -15786,14 +15786,14 @@ message ListHealthChecksRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for HealthChecks.Patch. See the method description for details.
 message PatchHealthCheckRequest {
   // Name of the HealthCheck resource to patch.
-  string health_check = 40441189 [(google.api.field_behavior) = REQUIRED];
+  string health_check = 308876645 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   HealthCheck health_check_resource = 201925032 [(google.api.field_behavior) = REQUIRED];
@@ -15813,7 +15813,7 @@ message PatchHealthCheckRequest {
 // A request message for HealthChecks.Update. See the method description for details.
 message UpdateHealthCheckRequest {
   // Name of the HealthCheck resource to update.
-  string health_check = 40441189 [(google.api.field_behavior) = REQUIRED];
+  string health_check = 308876645 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   HealthCheck health_check_resource = 201925032 [(google.api.field_behavior) = REQUIRED];
@@ -15850,7 +15850,7 @@ message DeleteImageRequest {
 // A request message for Images.Deprecate. See the method description for details.
 message DeprecateImageRequest {
   // The body resource for this request
-  DeprecationStatus deprecation_status_resource = 64570608 [(google.api.field_behavior) = REQUIRED];
+  DeprecationStatus deprecation_status_resource = 333006064 [(google.api.field_behavior) = REQUIRED];
 
   // Image name.
   string image = 100313435 [(google.api.field_behavior) = REQUIRED];
@@ -15880,7 +15880,7 @@ message GetImageRequest {
 // A request message for Images.GetFromFamily. See the method description for details.
 message GetFromFamilyImageRequest {
   // Name of the image family to search for.
-  string family = 60316516 [(google.api.field_behavior) = REQUIRED];
+  string family = 328751972 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15890,7 +15890,7 @@ message GetFromFamilyImageRequest {
 // A request message for Images.GetIamPolicy. See the method description for details.
 message GetIamPolicyImageRequest {
   // Requested IAM Policy version.
-  optional int32 options_requested_policy_version = 230784573;
+  optional int32 options_requested_policy_version = 499220029;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15906,7 +15906,7 @@ message InsertImageRequest {
   optional bool force_create = 197723344;
 
   // The body resource for this request
-  Image image_resource = 102736498 [(google.api.field_behavior) = REQUIRED];
+  Image image_resource = 371171954 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15929,7 +15929,7 @@ message ListImagesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -15948,7 +15948,7 @@ message ListImagesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -15958,7 +15958,7 @@ message PatchImageRequest {
   string image = 100313435 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  Image image_resource = 102736498 [(google.api.field_behavior) = REQUIRED];
+  Image image_resource = 371171954 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15975,7 +15975,7 @@ message PatchImageRequest {
 // A request message for Images.SetIamPolicy. See the method description for details.
 message SetIamPolicyImageRequest {
   // The body resource for this request
-  GlobalSetPolicyRequest global_set_policy_request_resource = 68613042 [(google.api.field_behavior) = REQUIRED];
+  GlobalSetPolicyRequest global_set_policy_request_resource = 337048498 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -15988,7 +15988,7 @@ message SetIamPolicyImageRequest {
 // A request message for Images.SetLabels. See the method description for details.
 message SetLabelsImageRequest {
   // The body resource for this request
-  GlobalSetLabelsRequest global_set_labels_request_resource = 51481733 [(google.api.field_behavior) = REQUIRED];
+  GlobalSetLabelsRequest global_set_labels_request_resource = 319917189 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -16007,7 +16007,7 @@ message TestIamPermissionsImageRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -16017,7 +16017,7 @@ message AbandonInstancesInstanceGroupManagerRequest {
   string instance_group_manager = 249363395 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  InstanceGroupManagersAbandonInstancesRequest instance_group_managers_abandon_instances_request_resource = 52493560 [(google.api.field_behavior) = REQUIRED];
+  InstanceGroupManagersAbandonInstancesRequest instance_group_managers_abandon_instances_request_resource = 320929016 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -16043,10 +16043,10 @@ message AggregatedListInstanceGroupManagersRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -16065,7 +16065,7 @@ message AggregatedListInstanceGroupManagersRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -16157,7 +16157,7 @@ message DeletePerInstanceConfigsInstanceGroupManagerRequest {
   string instance_group_manager = 249363395 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  InstanceGroupManagersDeletePerInstanceConfigsReq instance_group_managers_delete_per_instance_configs_req_resource = 93992224 [(google.api.field_behavior) = REQUIRED];
+  InstanceGroupManagersDeletePerInstanceConfigsReq instance_group_managers_delete_per_instance_configs_req_resource = 362427680 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -16209,7 +16209,7 @@ message ListInstanceGroupManagersRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -16228,7 +16228,7 @@ message ListInstanceGroupManagersRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone where the managed instance group is located.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -16244,7 +16244,7 @@ message ListErrorsInstanceGroupManagersRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The name of the managed instance group. It must be a string that meets the requirements in RFC1035, or an unsigned long integer: must match regexp pattern: (?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)|[1-9][0-9]{0,19}.
   string instance_group_manager = 249363395 [(google.api.field_behavior) = REQUIRED];
@@ -16266,7 +16266,7 @@ message ListErrorsInstanceGroupManagersRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone where the managed instance group is located. It should conform to RFC1035.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -16282,7 +16282,7 @@ message ListManagedInstancesInstanceGroupManagersRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The name of the managed instance group.
   string instance_group_manager = 249363395 [(google.api.field_behavior) = REQUIRED];
@@ -16304,7 +16304,7 @@ message ListManagedInstancesInstanceGroupManagersRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone where the managed instance group is located.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -16320,7 +16320,7 @@ message ListPerInstanceConfigsInstanceGroupManagersRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The name of the managed instance group. It should conform to RFC1035.
   string instance_group_manager = 249363395 [(google.api.field_behavior) = REQUIRED];
@@ -16342,7 +16342,7 @@ message ListPerInstanceConfigsInstanceGroupManagersRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone where the managed instance group is located. It should conform to RFC1035.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -16378,7 +16378,7 @@ message PatchPerInstanceConfigsInstanceGroupManagerRequest {
   string instance_group_manager = 249363395 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  InstanceGroupManagersPatchPerInstanceConfigsReq instance_group_managers_patch_per_instance_configs_req_resource = 88215039 [(google.api.field_behavior) = REQUIRED];
+  InstanceGroupManagersPatchPerInstanceConfigsReq instance_group_managers_patch_per_instance_configs_req_resource = 356650495 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -16470,7 +16470,7 @@ message SetTargetPoolsInstanceGroupManagerRequest {
   string instance_group_manager = 249363395 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  InstanceGroupManagersSetTargetPoolsRequest instance_group_managers_set_target_pools_request_resource = 12714760 [(google.api.field_behavior) = REQUIRED];
+  InstanceGroupManagersSetTargetPoolsRequest instance_group_managers_set_target_pools_request_resource = 281150216 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -16516,7 +16516,7 @@ message AddInstancesInstanceGroupRequest {
   string instance_group = 81095253 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  InstanceGroupsAddInstancesRequest instance_groups_add_instances_request_resource = 185277790 [(google.api.field_behavior) = REQUIRED];
+  InstanceGroupsAddInstancesRequest instance_groups_add_instances_request_resource = 453713246 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -16542,10 +16542,10 @@ message AggregatedListInstanceGroupsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -16564,7 +16564,7 @@ message AggregatedListInstanceGroupsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -16604,7 +16604,7 @@ message GetInstanceGroupRequest {
 // A request message for InstanceGroups.Insert. See the method description for details.
 message InsertInstanceGroupRequest {
   // The body resource for this request
-  InstanceGroup instance_group_resource = 18176696 [(google.api.field_behavior) = REQUIRED];
+  InstanceGroup instance_group_resource = 286612152 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -16630,7 +16630,7 @@ message ListInstanceGroupsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -16649,7 +16649,7 @@ message ListInstanceGroupsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone where the instance group is located.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -16665,13 +16665,13 @@ message ListInstancesInstanceGroupsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The name of the instance group from which you want to generate a list of included instances.
   string instance_group = 81095253 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  InstanceGroupsListInstancesRequest instance_groups_list_instances_request_resource = 207819807 [(google.api.field_behavior) = REQUIRED];
+  InstanceGroupsListInstancesRequest instance_groups_list_instances_request_resource = 476255263 [(google.api.field_behavior) = REQUIRED];
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -16690,7 +16690,7 @@ message ListInstancesInstanceGroupsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone where the instance group is located.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -16703,7 +16703,7 @@ message RemoveInstancesInstanceGroupRequest {
   string instance_group = 81095253 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  InstanceGroupsRemoveInstancesRequest instance_groups_remove_instances_request_resource = 122546361 [(google.api.field_behavior) = REQUIRED];
+  InstanceGroupsRemoveInstancesRequest instance_groups_remove_instances_request_resource = 390981817 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -16726,7 +16726,7 @@ message SetNamedPortsInstanceGroupRequest {
   string instance_group = 81095253 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  InstanceGroupsSetNamedPortsRequest instance_groups_set_named_ports_request_resource = 116716079 [(google.api.field_behavior) = REQUIRED];
+  InstanceGroupsSetNamedPortsRequest instance_groups_set_named_ports_request_resource = 385151535 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -16746,7 +16746,7 @@ message SetNamedPortsInstanceGroupRequest {
 // A request message for InstanceTemplates.Delete. See the method description for details.
 message DeleteInstanceTemplateRequest {
   // The name of the instance template to delete.
-  string instance_template = 40812772 [(google.api.field_behavior) = REQUIRED];
+  string instance_template = 309248228 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -16763,7 +16763,7 @@ message DeleteInstanceTemplateRequest {
 // A request message for InstanceTemplates.Get. See the method description for details.
 message GetInstanceTemplateRequest {
   // The name of the instance template.
-  string instance_template = 40812772 [(google.api.field_behavior) = REQUIRED];
+  string instance_template = 309248228 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -16773,7 +16773,7 @@ message GetInstanceTemplateRequest {
 // A request message for InstanceTemplates.GetIamPolicy. See the method description for details.
 message GetIamPolicyInstanceTemplateRequest {
   // Requested IAM Policy version.
-  optional int32 options_requested_policy_version = 230784573;
+  optional int32 options_requested_policy_version = 499220029;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -16809,7 +16809,7 @@ message ListInstanceTemplatesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -16828,14 +16828,14 @@ message ListInstanceTemplatesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for InstanceTemplates.SetIamPolicy. See the method description for details.
 message SetIamPolicyInstanceTemplateRequest {
   // The body resource for this request
-  GlobalSetPolicyRequest global_set_policy_request_resource = 68613042 [(google.api.field_behavior) = REQUIRED];
+  GlobalSetPolicyRequest global_set_policy_request_resource = 337048498 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -16854,20 +16854,20 @@ message TestIamPermissionsInstanceTemplateRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
 }
 
 // A request message for Instances.AddAccessConfig. See the method description for details.
 message AddAccessConfigInstanceRequest {
   // The body resource for this request
-  AccessConfig access_config_resource = 119390096 [(google.api.field_behavior) = REQUIRED];
+  AccessConfig access_config_resource = 387825552 [(google.api.field_behavior) = REQUIRED];
 
   // The instance name for this request.
   string instance = 18257045 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the network interface to add to this instance.
-  string network_interface = 96952424 [(google.api.field_behavior) = REQUIRED];
+  string network_interface = 365387880 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -16890,7 +16890,7 @@ message AddResourcePoliciesInstanceRequest {
   string instance = 18257045 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  InstancesAddResourcePoliciesRequest instances_add_resource_policies_request_resource = 220916507 [(google.api.field_behavior) = REQUIRED];
+  InstancesAddResourcePoliciesRequest instances_add_resource_policies_request_resource = 489351963 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -16916,10 +16916,10 @@ message AggregatedListInstancesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -16938,7 +16938,7 @@ message AggregatedListInstancesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -16997,7 +16997,7 @@ message DeleteAccessConfigInstanceRequest {
   string instance = 18257045 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the network interface.
-  string network_interface = 96952424 [(google.api.field_behavior) = REQUIRED];
+  string network_interface = 365387880 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -17059,7 +17059,7 @@ message GetGuestAttributesInstanceRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Specifies the guest attributes path to be queried.
-  optional string query_path = 100155708;
+  optional string query_path = 368591164;
 
   // Specifies the key for the guest attributes entry.
   optional string variable_key = 164364828;
@@ -17072,7 +17072,7 @@ message GetGuestAttributesInstanceRequest {
 // A request message for Instances.GetIamPolicy. See the method description for details.
 message GetIamPolicyInstanceRequest {
   // Requested IAM Policy version.
-  optional int32 options_requested_policy_version = 230784573;
+  optional int32 options_requested_policy_version = 499220029;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -17155,7 +17155,7 @@ message InsertInstanceRequest {
   // - https://www.googleapis.com/compute/v1/projects/project/global/instanceTemplates/instanceTemplate
   // - projects/project/global/instanceTemplates/instanceTemplate
   // - global/instanceTemplates/instanceTemplate
-  optional string source_instance_template = 63988160;
+  optional string source_instance_template = 332423616;
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -17171,7 +17171,7 @@ message ListInstancesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -17190,7 +17190,7 @@ message ListInstancesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -17206,7 +17206,7 @@ message ListReferrersInstancesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Name of the target instance scoping this request, or '-' if the request should span over all instances in the container.
   string instance = 18257045 [(google.api.field_behavior) = REQUIRED];
@@ -17228,7 +17228,7 @@ message ListReferrersInstancesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -17281,7 +17281,7 @@ message ResetInstanceRequest {
 // A request message for Instances.SetDeletionProtection. See the method description for details.
 message SetDeletionProtectionInstanceRequest {
   // Whether the resource should be protected against deletion.
-  optional bool deletion_protection = 189579242;
+  optional bool deletion_protection = 458014698;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -17304,7 +17304,7 @@ message SetDeletionProtectionInstanceRequest {
 // A request message for Instances.SetDiskAutoDelete. See the method description for details.
 message SetDiskAutoDeleteInstanceRequest {
   // Whether to auto-delete the disk when the instance is deleted.
-  bool auto_delete = 196325947 [(google.api.field_behavior) = REQUIRED];
+  bool auto_delete = 464761403 [(google.api.field_behavior) = REQUIRED];
 
   // The device name of the disk to modify. Make a get() request on the instance to view currently attached disks and device names.
   string device_name = 67541716 [(google.api.field_behavior) = REQUIRED];
@@ -17339,7 +17339,7 @@ message SetIamPolicyInstanceRequest {
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  ZoneSetPolicyRequest zone_set_policy_request_resource = 113646651 [(google.api.field_behavior) = REQUIRED];
+  ZoneSetPolicyRequest zone_set_policy_request_resource = 382082107 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -17418,7 +17418,7 @@ message SetMetadataInstanceRequest {
   string instance = 18257045 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  Metadata metadata_resource = 22650654 [(google.api.field_behavior) = REQUIRED];
+  Metadata metadata_resource = 291086110 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -17474,7 +17474,7 @@ message SetSchedulingInstanceRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  Scheduling scheduling_resource = 194745945 [(google.api.field_behavior) = REQUIRED];
+  Scheduling scheduling_resource = 463181401 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -17487,7 +17487,7 @@ message SetServiceAccountInstanceRequest {
   string instance = 18257045 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  InstancesSetServiceAccountRequest instances_set_service_account_request_resource = 7114552 [(google.api.field_behavior) = REQUIRED];
+  InstancesSetServiceAccountRequest instances_set_service_account_request_resource = 275550008 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -17520,7 +17520,7 @@ message SetShieldedInstanceIntegrityPolicyInstanceRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  ShieldedInstanceIntegrityPolicy shielded_instance_integrity_policy_resource = 140734006 [(google.api.field_behavior) = REQUIRED];
+  ShieldedInstanceIntegrityPolicy shielded_instance_integrity_policy_resource = 409169462 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -17543,7 +17543,7 @@ message SetTagsInstanceRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  Tags tags_resource = 62999924 [(google.api.field_behavior) = REQUIRED];
+  Tags tags_resource = 331435380 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -17589,7 +17589,7 @@ message StartWithEncryptionKeyInstanceRequest {
   string instance = 18257045 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  InstancesStartWithEncryptionKeyRequest instances_start_with_encryption_key_request_resource = 173277055 [(google.api.field_behavior) = REQUIRED];
+  InstancesStartWithEncryptionKeyRequest instances_start_with_encryption_key_request_resource = 441712511 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -17635,7 +17635,7 @@ message TestIamPermissionsInstanceRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -17651,7 +17651,7 @@ message UpdateInstanceRequest {
   Instance instance_resource = 215988344 [(google.api.field_behavior) = REQUIRED];
 
   // Specifies the action to take when updating an instance even if the updated properties do not require it. If not specified, then Compute Engine acts based on the minimum action that the updated properties require.
-  optional string minimal_action = 2131604;
+  optional string minimal_action = 270567060;
 
   // Specifies the most disruptive action that can be taken on the instance as part of the update. Compute Engine returns an error if the instance properties require a more disruptive action as part of the instance update. Valid options from lowest to highest are NO_EFFECT, REFRESH, and RESTART.
   optional string most_disruptive_allowed_action = 66103053;
@@ -17674,13 +17674,13 @@ message UpdateInstanceRequest {
 // A request message for Instances.UpdateAccessConfig. See the method description for details.
 message UpdateAccessConfigInstanceRequest {
   // The body resource for this request
-  AccessConfig access_config_resource = 119390096 [(google.api.field_behavior) = REQUIRED];
+  AccessConfig access_config_resource = 387825552 [(google.api.field_behavior) = REQUIRED];
 
   // The instance name for this request.
   string instance = 18257045 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the network interface where the access config is attached.
-  string network_interface = 96952424 [(google.api.field_behavior) = REQUIRED];
+  string network_interface = 365387880 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -17700,7 +17700,7 @@ message UpdateAccessConfigInstanceRequest {
 // A request message for Instances.UpdateDisplayDevice. See the method description for details.
 message UpdateDisplayDeviceInstanceRequest {
   // The body resource for this request
-  DisplayDevice display_device_resource = 21250650 [(google.api.field_behavior) = REQUIRED];
+  DisplayDevice display_device_resource = 289686106 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the instance scoping this request.
   string instance = 18257045 [(google.api.field_behavior) = REQUIRED];
@@ -17726,10 +17726,10 @@ message UpdateNetworkInterfaceInstanceRequest {
   string instance = 18257045 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the network interface to update.
-  string network_interface = 96952424 [(google.api.field_behavior) = REQUIRED];
+  string network_interface = 365387880 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  NetworkInterface network_interface_resource = 57379333 [(google.api.field_behavior) = REQUIRED];
+  NetworkInterface network_interface_resource = 325814789 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -17762,7 +17762,7 @@ message UpdateShieldedInstanceConfigInstanceRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  ShieldedInstanceConfig shielded_instance_config_resource = 3623768 [(google.api.field_behavior) = REQUIRED];
+  ShieldedInstanceConfig shielded_instance_config_resource = 272059224 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -17778,10 +17778,10 @@ message AggregatedListInterconnectAttachmentsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -17800,14 +17800,14 @@ message AggregatedListInterconnectAttachmentsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for InterconnectAttachments.Delete. See the method description for details.
 message DeleteInterconnectAttachmentRequest {
   // Name of the interconnect attachment to delete.
-  string interconnect_attachment = 39699828 [(google.api.field_behavior) = REQUIRED];
+  string interconnect_attachment = 308135284 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -17827,7 +17827,7 @@ message DeleteInterconnectAttachmentRequest {
 // A request message for InterconnectAttachments.Get. See the method description for details.
 message GetInterconnectAttachmentRequest {
   // Name of the interconnect attachment to return.
-  string interconnect_attachment = 39699828 [(google.api.field_behavior) = REQUIRED];
+  string interconnect_attachment = 308135284 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -17869,7 +17869,7 @@ message ListInterconnectAttachmentsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -17891,14 +17891,14 @@ message ListInterconnectAttachmentsRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for InterconnectAttachments.Patch. See the method description for details.
 message PatchInterconnectAttachmentRequest {
   // Name of the interconnect attachment to patch.
-  string interconnect_attachment = 39699828 [(google.api.field_behavior) = REQUIRED];
+  string interconnect_attachment = 308135284 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   InterconnectAttachment interconnect_attachment_resource = 212341369 [(google.api.field_behavior) = REQUIRED];
@@ -17921,7 +17921,7 @@ message PatchInterconnectAttachmentRequest {
 // A request message for InterconnectLocations.Get. See the method description for details.
 message GetInterconnectLocationRequest {
   // Name of the interconnect location to return.
-  string interconnect_location = 223800390 [(google.api.field_behavior) = REQUIRED];
+  string interconnect_location = 492235846 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -17937,7 +17937,7 @@ message ListInterconnectLocationsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -17956,7 +17956,7 @@ message ListInterconnectLocationsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -18000,7 +18000,7 @@ message GetDiagnosticsInterconnectRequest {
 // A request message for Interconnects.Insert. See the method description for details.
 message InsertInterconnectRequest {
   // The body resource for this request
-  Interconnect interconnect_resource = 129175711 [(google.api.field_behavior) = REQUIRED];
+  Interconnect interconnect_resource = 397611167 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -18023,7 +18023,7 @@ message ListInterconnectsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -18042,7 +18042,7 @@ message ListInterconnectsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -18052,7 +18052,7 @@ message PatchInterconnectRequest {
   string interconnect = 224601230 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  Interconnect interconnect_resource = 129175711 [(google.api.field_behavior) = REQUIRED];
+  Interconnect interconnect_resource = 397611167 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -18085,7 +18085,7 @@ message TestIamPermissionsLicenseCodeRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -18119,7 +18119,7 @@ message GetLicenseRequest {
 // A request message for Licenses.GetIamPolicy. See the method description for details.
 message GetIamPolicyLicenseRequest {
   // Requested IAM Policy version.
-  optional int32 options_requested_policy_version = 230784573;
+  optional int32 options_requested_policy_version = 499220029;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -18132,7 +18132,7 @@ message GetIamPolicyLicenseRequest {
 // A request message for Licenses.Insert. See the method description for details.
 message InsertLicenseRequest {
   // The body resource for this request
-  License license_resource = 169519692 [(google.api.field_behavior) = REQUIRED];
+  License license_resource = 437955148 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -18155,7 +18155,7 @@ message ListLicensesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -18174,14 +18174,14 @@ message ListLicensesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for Licenses.SetIamPolicy. See the method description for details.
 message SetIamPolicyLicenseRequest {
   // The body resource for this request
-  GlobalSetPolicyRequest global_set_policy_request_resource = 68613042 [(google.api.field_behavior) = REQUIRED];
+  GlobalSetPolicyRequest global_set_policy_request_resource = 337048498 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -18200,7 +18200,7 @@ message TestIamPermissionsLicenseRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -18213,10 +18213,10 @@ message AggregatedListMachineTypesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -18235,7 +18235,7 @@ message AggregatedListMachineTypesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -18261,7 +18261,7 @@ message ListMachineTypesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -18280,7 +18280,7 @@ message ListMachineTypesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -18296,10 +18296,10 @@ message AggregatedListNetworkEndpointGroupsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -18318,14 +18318,14 @@ message AggregatedListNetworkEndpointGroupsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for NetworkEndpointGroups.AttachNetworkEndpoints. See the method description for details.
 message AttachNetworkEndpointsNetworkEndpointGroupRequest {
   // The name of the network endpoint group where you are attaching network endpoints to. It should comply with RFC1035.
-  string network_endpoint_group = 165471622 [(google.api.field_behavior) = REQUIRED];
+  string network_endpoint_group = 433907078 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   NetworkEndpointGroupsAttachEndpointsRequest network_endpoint_groups_attach_endpoints_request_resource = 531079 [(google.api.field_behavior) = REQUIRED];
@@ -18348,7 +18348,7 @@ message AttachNetworkEndpointsNetworkEndpointGroupRequest {
 // A request message for NetworkEndpointGroups.Delete. See the method description for details.
 message DeleteNetworkEndpointGroupRequest {
   // The name of the network endpoint group to delete. It should comply with RFC1035.
-  string network_endpoint_group = 165471622 [(google.api.field_behavior) = REQUIRED];
+  string network_endpoint_group = 433907078 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -18368,10 +18368,10 @@ message DeleteNetworkEndpointGroupRequest {
 // A request message for NetworkEndpointGroups.DetachNetworkEndpoints. See the method description for details.
 message DetachNetworkEndpointsNetworkEndpointGroupRequest {
   // The name of the network endpoint group where you are removing network endpoints. It should comply with RFC1035.
-  string network_endpoint_group = 165471622 [(google.api.field_behavior) = REQUIRED];
+  string network_endpoint_group = 433907078 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  NetworkEndpointGroupsDetachEndpointsRequest network_endpoint_groups_detach_endpoints_request_resource = 247173241 [(google.api.field_behavior) = REQUIRED];
+  NetworkEndpointGroupsDetachEndpointsRequest network_endpoint_groups_detach_endpoints_request_resource = 515608697 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -18391,7 +18391,7 @@ message DetachNetworkEndpointsNetworkEndpointGroupRequest {
 // A request message for NetworkEndpointGroups.Get. See the method description for details.
 message GetNetworkEndpointGroupRequest {
   // The name of the network endpoint group. It should comply with RFC1035.
-  string network_endpoint_group = 165471622 [(google.api.field_behavior) = REQUIRED];
+  string network_endpoint_group = 433907078 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -18404,7 +18404,7 @@ message GetNetworkEndpointGroupRequest {
 // A request message for NetworkEndpointGroups.Insert. See the method description for details.
 message InsertNetworkEndpointGroupRequest {
   // The body resource for this request
-  NetworkEndpointGroup network_endpoint_group_resource = 257353383 [(google.api.field_behavior) = REQUIRED];
+  NetworkEndpointGroup network_endpoint_group_resource = 525788839 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -18430,7 +18430,7 @@ message ListNetworkEndpointGroupsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -18449,7 +18449,7 @@ message ListNetworkEndpointGroupsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone where the network endpoint group is located. It should comply with RFC1035.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -18465,13 +18465,13 @@ message ListNetworkEndpointsNetworkEndpointGroupsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
 
   // The name of the network endpoint group from which you want to generate a list of included network endpoints. It should comply with RFC1035.
-  string network_endpoint_group = 165471622 [(google.api.field_behavior) = REQUIRED];
+  string network_endpoint_group = 433907078 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   NetworkEndpointGroupsListEndpointsRequest network_endpoint_groups_list_endpoints_request_resource = 59493390 [(google.api.field_behavior) = REQUIRED];
@@ -18490,7 +18490,7 @@ message ListNetworkEndpointsNetworkEndpointGroupsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone where the network endpoint group is located. It should comply with RFC1035.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -18506,7 +18506,7 @@ message TestIamPermissionsNetworkEndpointGroupRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -18519,7 +18519,7 @@ message AddPeeringNetworkRequest {
   string network = 232872494 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  NetworksAddPeeringRequest networks_add_peering_request_resource = 120374965 [(google.api.field_behavior) = REQUIRED];
+  NetworksAddPeeringRequest networks_add_peering_request_resource = 388810421 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -18586,7 +18586,7 @@ message ListNetworksRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -18605,7 +18605,7 @@ message ListNetworksRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -18616,9 +18616,9 @@ message ListPeeringRoutesNetworksRequest {
     // A value indicating that the enum field is not set.
     UNDEFINED_DIRECTION = 0;
 
-    INCOMING = 70117414;
+    INCOMING = 338552870;
 
-    OUTGOING = 39002988;
+    OUTGOING = 307438444;
 
   }
 
@@ -18632,7 +18632,7 @@ message ListPeeringRoutesNetworksRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -18660,7 +18660,7 @@ message ListPeeringRoutesNetworksRequest {
   optional string region = 138946292;
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -18690,7 +18690,7 @@ message RemovePeeringNetworkRequest {
   string network = 232872494 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  NetworksRemovePeeringRequest networks_remove_peering_request_resource = 152727038 [(google.api.field_behavior) = REQUIRED];
+  NetworksRemovePeeringRequest networks_remove_peering_request_resource = 421162494 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -18744,7 +18744,7 @@ message UpdatePeeringNetworkRequest {
 // A request message for NodeGroups.AddNodes. See the method description for details.
 message AddNodesNodeGroupRequest {
   // Name of the NodeGroup resource.
-  string node_group = 201522690 [(google.api.field_behavior) = REQUIRED];
+  string node_group = 469958146 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   NodeGroupsAddNodesRequest node_groups_add_nodes_request_resource = 131263288 [(google.api.field_behavior) = REQUIRED];
@@ -18773,10 +18773,10 @@ message AggregatedListNodeGroupsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -18795,14 +18795,14 @@ message AggregatedListNodeGroupsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for NodeGroups.Delete. See the method description for details.
 message DeleteNodeGroupRequest {
   // Name of the NodeGroup resource to delete.
-  string node_group = 201522690 [(google.api.field_behavior) = REQUIRED];
+  string node_group = 469958146 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -18822,7 +18822,7 @@ message DeleteNodeGroupRequest {
 // A request message for NodeGroups.DeleteNodes. See the method description for details.
 message DeleteNodesNodeGroupRequest {
   // Name of the NodeGroup resource whose nodes will be deleted.
-  string node_group = 201522690 [(google.api.field_behavior) = REQUIRED];
+  string node_group = 469958146 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   NodeGroupsDeleteNodesRequest node_groups_delete_nodes_request_resource = 183298962 [(google.api.field_behavior) = REQUIRED];
@@ -18845,7 +18845,7 @@ message DeleteNodesNodeGroupRequest {
 // A request message for NodeGroups.Get. See the method description for details.
 message GetNodeGroupRequest {
   // Name of the node group to return.
-  string node_group = 201522690 [(google.api.field_behavior) = REQUIRED];
+  string node_group = 469958146 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -18858,7 +18858,7 @@ message GetNodeGroupRequest {
 // A request message for NodeGroups.GetIamPolicy. See the method description for details.
 message GetIamPolicyNodeGroupRequest {
   // Requested IAM Policy version.
-  optional int32 options_requested_policy_version = 230784573;
+  optional int32 options_requested_policy_version = 499220029;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -18877,7 +18877,7 @@ message InsertNodeGroupRequest {
   int32 initial_node_count = 71951469 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  NodeGroup node_group_resource = 236886443 [(google.api.field_behavior) = REQUIRED];
+  NodeGroup node_group_resource = 505321899 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -18903,7 +18903,7 @@ message ListNodeGroupsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -18922,7 +18922,7 @@ message ListNodeGroupsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -18938,13 +18938,13 @@ message ListNodesNodeGroupsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
 
   // Name of the NodeGroup resource whose nodes you want to list.
-  string node_group = 201522690 [(google.api.field_behavior) = REQUIRED];
+  string node_group = 469958146 [(google.api.field_behavior) = REQUIRED];
 
   // Sorts list results by a certain order. By default, results are returned in alphanumerical order based on the resource name.
   //
@@ -18960,7 +18960,7 @@ message ListNodesNodeGroupsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -18970,10 +18970,10 @@ message ListNodesNodeGroupsRequest {
 // A request message for NodeGroups.Patch. See the method description for details.
 message PatchNodeGroupRequest {
   // Name of the NodeGroup resource to update.
-  string node_group = 201522690 [(google.api.field_behavior) = REQUIRED];
+  string node_group = 469958146 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  NodeGroup node_group_resource = 236886443 [(google.api.field_behavior) = REQUIRED];
+  NodeGroup node_group_resource = 505321899 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19002,14 +19002,14 @@ message SetIamPolicyNodeGroupRequest {
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  ZoneSetPolicyRequest zone_set_policy_request_resource = 113646651 [(google.api.field_behavior) = REQUIRED];
+  ZoneSetPolicyRequest zone_set_policy_request_resource = 382082107 [(google.api.field_behavior) = REQUIRED];
 
 }
 
 // A request message for NodeGroups.SetNodeTemplate. See the method description for details.
 message SetNodeTemplateNodeGroupRequest {
   // Name of the NodeGroup resource to update.
-  string node_group = 201522690 [(google.api.field_behavior) = REQUIRED];
+  string node_group = 469958146 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   NodeGroupsSetNodeTemplateRequest node_groups_set_node_template_request_resource = 117382321 [(google.api.field_behavior) = REQUIRED];
@@ -19038,7 +19038,7 @@ message TestIamPermissionsNodeGroupRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -19054,10 +19054,10 @@ message AggregatedListNodeTemplatesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -19076,14 +19076,14 @@ message AggregatedListNodeTemplatesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for NodeTemplates.Delete. See the method description for details.
 message DeleteNodeTemplateRequest {
   // Name of the NodeTemplate resource to delete.
-  string node_template = 54718999 [(google.api.field_behavior) = REQUIRED];
+  string node_template = 323154455 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19103,7 +19103,7 @@ message DeleteNodeTemplateRequest {
 // A request message for NodeTemplates.Get. See the method description for details.
 message GetNodeTemplateRequest {
   // Name of the node template to return.
-  string node_template = 54718999 [(google.api.field_behavior) = REQUIRED];
+  string node_template = 323154455 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19116,7 +19116,7 @@ message GetNodeTemplateRequest {
 // A request message for NodeTemplates.GetIamPolicy. See the method description for details.
 message GetIamPolicyNodeTemplateRequest {
   // Requested IAM Policy version.
-  optional int32 options_requested_policy_version = 230784573;
+  optional int32 options_requested_policy_version = 499220029;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19158,7 +19158,7 @@ message ListNodeTemplatesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -19180,7 +19180,7 @@ message ListNodeTemplatesRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -19193,7 +19193,7 @@ message SetIamPolicyNodeTemplateRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  RegionSetPolicyRequest region_set_policy_request_resource = 8053635 [(google.api.field_behavior) = REQUIRED];
+  RegionSetPolicyRequest region_set_policy_request_resource = 276489091 [(google.api.field_behavior) = REQUIRED];
 
   // Name or id of the resource for this request.
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
@@ -19212,7 +19212,7 @@ message TestIamPermissionsNodeTemplateRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -19225,10 +19225,10 @@ message AggregatedListNodeTypesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -19247,14 +19247,14 @@ message AggregatedListNodeTypesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for NodeTypes.Get. See the method description for details.
 message GetNodeTypeRequest {
   // Name of the node type to return.
-  string node_type = 197397335 [(google.api.field_behavior) = REQUIRED];
+  string node_type = 465832791 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19273,7 +19273,7 @@ message ListNodeTypesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -19292,7 +19292,7 @@ message ListNodeTypesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -19308,10 +19308,10 @@ message AggregatedListPacketMirroringsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -19330,7 +19330,7 @@ message AggregatedListPacketMirroringsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -19370,7 +19370,7 @@ message GetPacketMirroringRequest {
 // A request message for PacketMirrorings.Insert. See the method description for details.
 message InsertPacketMirroringRequest {
   // The body resource for this request
-  PacketMirroring packet_mirroring_resource = 225066529 [(google.api.field_behavior) = REQUIRED];
+  PacketMirroring packet_mirroring_resource = 493501985 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19396,7 +19396,7 @@ message ListPacketMirroringsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -19418,7 +19418,7 @@ message ListPacketMirroringsRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -19428,7 +19428,7 @@ message PatchPacketMirroringRequest {
   string packet_mirroring = 22305996 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  PacketMirroring packet_mirroring_resource = 225066529 [(google.api.field_behavior) = REQUIRED];
+  PacketMirroring packet_mirroring_resource = 493501985 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19457,7 +19457,7 @@ message TestIamPermissionsPacketMirroringRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -19512,7 +19512,7 @@ message EnableXpnResourceProjectRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  ProjectsEnableXpnResourceRequest projects_enable_xpn_resource_request_resource = 153544751 [(google.api.field_behavior) = REQUIRED];
+  ProjectsEnableXpnResourceRequest projects_enable_xpn_resource_request_resource = 421980207 [(google.api.field_behavior) = REQUIRED];
 
   // An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed.
   //
@@ -19546,7 +19546,7 @@ message GetXpnResourcesProjectsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -19565,7 +19565,7 @@ message GetXpnResourcesProjectsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -19578,7 +19578,7 @@ message ListXpnHostsProjectsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -19600,14 +19600,14 @@ message ListXpnHostsProjectsRequest {
   ProjectsListXpnHostsRequest projects_list_xpn_hosts_request_resource = 238266391 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for Projects.MoveDisk. See the method description for details.
 message MoveDiskProjectRequest {
   // The body resource for this request
-  DiskMoveRequest disk_move_request_resource = 44573002 [(google.api.field_behavior) = REQUIRED];
+  DiskMoveRequest disk_move_request_resource = 313008458 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19624,7 +19624,7 @@ message MoveDiskProjectRequest {
 // A request message for Projects.MoveInstance. See the method description for details.
 message MoveInstanceProjectRequest {
   // The body resource for this request
-  InstanceMoveRequest instance_move_request_resource = 43228738 [(google.api.field_behavior) = REQUIRED];
+  InstanceMoveRequest instance_move_request_resource = 311664194 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19641,7 +19641,7 @@ message MoveInstanceProjectRequest {
 // A request message for Projects.SetCommonInstanceMetadata. See the method description for details.
 message SetCommonInstanceMetadataProjectRequest {
   // The body resource for this request
-  Metadata metadata_resource = 22650654 [(google.api.field_behavior) = REQUIRED];
+  Metadata metadata_resource = 291086110 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19692,7 +19692,7 @@ message SetUsageExportBucketProjectRequest {
 // A request message for RegionAutoscalers.Delete. See the method description for details.
 message DeleteRegionAutoscalerRequest {
   // Name of the autoscaler to delete.
-  string autoscaler = 248823511 [(google.api.field_behavior) = REQUIRED];
+  string autoscaler = 517258967 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19712,7 +19712,7 @@ message DeleteRegionAutoscalerRequest {
 // A request message for RegionAutoscalers.Get. See the method description for details.
 message GetRegionAutoscalerRequest {
   // Name of the autoscaler to return.
-  string autoscaler = 248823511 [(google.api.field_behavior) = REQUIRED];
+  string autoscaler = 517258967 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19751,7 +19751,7 @@ message ListRegionAutoscalersRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -19773,14 +19773,14 @@ message ListRegionAutoscalersRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for RegionAutoscalers.Patch. See the method description for details.
 message PatchRegionAutoscalerRequest {
   // Name of the autoscaler to patch.
-  optional string autoscaler = 248823511;
+  optional string autoscaler = 517258967;
 
   // The body resource for this request
   Autoscaler autoscaler_resource = 207616118 [(google.api.field_behavior) = REQUIRED];
@@ -19803,7 +19803,7 @@ message PatchRegionAutoscalerRequest {
 // A request message for RegionAutoscalers.Update. See the method description for details.
 message UpdateRegionAutoscalerRequest {
   // Name of the autoscaler to update.
-  optional string autoscaler = 248823511;
+  optional string autoscaler = 517258967;
 
   // The body resource for this request
   Autoscaler autoscaler_resource = 207616118 [(google.api.field_behavior) = REQUIRED];
@@ -19826,7 +19826,7 @@ message UpdateRegionAutoscalerRequest {
 // A request message for RegionBackendServices.Delete. See the method description for details.
 message DeleteRegionBackendServiceRequest {
   // Name of the BackendService resource to delete.
-  string backend_service = 38510602 [(google.api.field_behavior) = REQUIRED];
+  string backend_service = 306946058 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19846,7 +19846,7 @@ message DeleteRegionBackendServiceRequest {
 // A request message for RegionBackendServices.Get. See the method description for details.
 message GetRegionBackendServiceRequest {
   // Name of the BackendService resource to return.
-  string backend_service = 38510602 [(google.api.field_behavior) = REQUIRED];
+  string backend_service = 306946058 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19859,7 +19859,7 @@ message GetRegionBackendServiceRequest {
 // A request message for RegionBackendServices.GetHealth. See the method description for details.
 message GetHealthRegionBackendServiceRequest {
   // Name of the BackendService resource for which to get health.
-  string backend_service = 38510602 [(google.api.field_behavior) = REQUIRED];
+  string backend_service = 306946058 [(google.api.field_behavior) = REQUIRED];
 
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
@@ -19874,7 +19874,7 @@ message GetHealthRegionBackendServiceRequest {
 // A request message for RegionBackendServices.Insert. See the method description for details.
 message InsertRegionBackendServiceRequest {
   // The body resource for this request
-  BackendService backend_service_resource = 79151267 [(google.api.field_behavior) = REQUIRED];
+  BackendService backend_service_resource = 347586723 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19900,7 +19900,7 @@ message ListRegionBackendServicesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -19922,17 +19922,17 @@ message ListRegionBackendServicesRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for RegionBackendServices.Patch. See the method description for details.
 message PatchRegionBackendServiceRequest {
   // Name of the BackendService resource to patch.
-  string backend_service = 38510602 [(google.api.field_behavior) = REQUIRED];
+  string backend_service = 306946058 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  BackendService backend_service_resource = 79151267 [(google.api.field_behavior) = REQUIRED];
+  BackendService backend_service_resource = 347586723 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19952,10 +19952,10 @@ message PatchRegionBackendServiceRequest {
 // A request message for RegionBackendServices.Update. See the method description for details.
 message UpdateRegionBackendServiceRequest {
   // Name of the BackendService resource to update.
-  string backend_service = 38510602 [(google.api.field_behavior) = REQUIRED];
+  string backend_service = 306946058 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  BackendService backend_service_resource = 79151267 [(google.api.field_behavior) = REQUIRED];
+  BackendService backend_service_resource = 347586723 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -19981,10 +19981,10 @@ message AggregatedListRegionCommitmentsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -20003,14 +20003,14 @@ message AggregatedListRegionCommitmentsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for RegionCommitments.Get. See the method description for details.
 message GetRegionCommitmentRequest {
   // Name of the commitment to return.
-  string commitment = 213699349 [(google.api.field_behavior) = REQUIRED];
+  string commitment = 482134805 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -20049,7 +20049,7 @@ message ListRegionCommitmentsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -20071,7 +20071,7 @@ message ListRegionCommitmentsRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -20097,7 +20097,7 @@ message ListRegionDiskTypesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -20119,7 +20119,7 @@ message ListRegionDiskTypesRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -20135,7 +20135,7 @@ message AddResourcePoliciesRegionDiskRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  RegionDisksAddResourcePoliciesRequest region_disks_add_resource_policies_request_resource = 15761294 [(google.api.field_behavior) = REQUIRED];
+  RegionDisksAddResourcePoliciesRequest region_disks_add_resource_policies_request_resource = 284196750 [(google.api.field_behavior) = REQUIRED];
 
   // An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed.
   //
@@ -20165,7 +20165,7 @@ message CreateSnapshotRegionDiskRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  Snapshot snapshot_resource = 212884521 [(google.api.field_behavior) = REQUIRED];
+  Snapshot snapshot_resource = 481319977 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -20205,7 +20205,7 @@ message GetRegionDiskRequest {
 // A request message for RegionDisks.GetIamPolicy. See the method description for details.
 message GetIamPolicyRegionDiskRequest {
   // Requested IAM Policy version.
-  optional int32 options_requested_policy_version = 230784573;
+  optional int32 options_requested_policy_version = 499220029;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -20250,7 +20250,7 @@ message ListRegionDisksRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -20272,7 +20272,7 @@ message ListRegionDisksRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -20311,7 +20311,7 @@ message ResizeRegionDiskRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  RegionDisksResizeRequest region_disks_resize_request_resource = 178197781 [(google.api.field_behavior) = REQUIRED];
+  RegionDisksResizeRequest region_disks_resize_request_resource = 446633237 [(google.api.field_behavior) = REQUIRED];
 
   // An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed.
   //
@@ -20331,7 +20331,7 @@ message SetIamPolicyRegionDiskRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  RegionSetPolicyRequest region_set_policy_request_resource = 8053635 [(google.api.field_behavior) = REQUIRED];
+  RegionSetPolicyRequest region_set_policy_request_resource = 276489091 [(google.api.field_behavior) = REQUIRED];
 
   // Name or id of the resource for this request.
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
@@ -20373,14 +20373,14 @@ message TestIamPermissionsRegionDiskRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
 }
 
 // A request message for RegionHealthCheckServices.Delete. See the method description for details.
 message DeleteRegionHealthCheckServiceRequest {
   // Name of the HealthCheckService to delete. The name must be 1-63 characters long, and comply with RFC1035.
-  string health_check_service = 139939291 [(google.api.field_behavior) = REQUIRED];
+  string health_check_service = 408374747 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -20400,7 +20400,7 @@ message DeleteRegionHealthCheckServiceRequest {
 // A request message for RegionHealthCheckServices.Get. See the method description for details.
 message GetRegionHealthCheckServiceRequest {
   // Name of the HealthCheckService to update. The name must be 1-63 characters long, and comply with RFC1035.
-  string health_check_service = 139939291 [(google.api.field_behavior) = REQUIRED];
+  string health_check_service = 408374747 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -20413,7 +20413,7 @@ message GetRegionHealthCheckServiceRequest {
 // A request message for RegionHealthCheckServices.Insert. See the method description for details.
 message InsertRegionHealthCheckServiceRequest {
   // The body resource for this request
-  HealthCheckService health_check_service_resource = 208932338 [(google.api.field_behavior) = REQUIRED];
+  HealthCheckService health_check_service_resource = 477367794 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -20439,7 +20439,7 @@ message ListRegionHealthCheckServicesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -20461,17 +20461,17 @@ message ListRegionHealthCheckServicesRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for RegionHealthCheckServices.Patch. See the method description for details.
 message PatchRegionHealthCheckServiceRequest {
   // Name of the HealthCheckService to update. The name must be 1-63 characters long, and comply with RFC1035.
-  string health_check_service = 139939291 [(google.api.field_behavior) = REQUIRED];
+  string health_check_service = 408374747 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  HealthCheckService health_check_service_resource = 208932338 [(google.api.field_behavior) = REQUIRED];
+  HealthCheckService health_check_service_resource = 477367794 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -20491,7 +20491,7 @@ message PatchRegionHealthCheckServiceRequest {
 // A request message for RegionHealthChecks.Delete. See the method description for details.
 message DeleteRegionHealthCheckRequest {
   // Name of the HealthCheck resource to delete.
-  string health_check = 40441189 [(google.api.field_behavior) = REQUIRED];
+  string health_check = 308876645 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -20511,7 +20511,7 @@ message DeleteRegionHealthCheckRequest {
 // A request message for RegionHealthChecks.Get. See the method description for details.
 message GetRegionHealthCheckRequest {
   // Name of the HealthCheck resource to return.
-  string health_check = 40441189 [(google.api.field_behavior) = REQUIRED];
+  string health_check = 308876645 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -20550,7 +20550,7 @@ message ListRegionHealthChecksRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -20572,14 +20572,14 @@ message ListRegionHealthChecksRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for RegionHealthChecks.Patch. See the method description for details.
 message PatchRegionHealthCheckRequest {
   // Name of the HealthCheck resource to patch.
-  string health_check = 40441189 [(google.api.field_behavior) = REQUIRED];
+  string health_check = 308876645 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   HealthCheck health_check_resource = 201925032 [(google.api.field_behavior) = REQUIRED];
@@ -20602,7 +20602,7 @@ message PatchRegionHealthCheckRequest {
 // A request message for RegionHealthChecks.Update. See the method description for details.
 message UpdateRegionHealthCheckRequest {
   // Name of the HealthCheck resource to update.
-  string health_check = 40441189 [(google.api.field_behavior) = REQUIRED];
+  string health_check = 308876645 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   HealthCheck health_check_resource = 201925032 [(google.api.field_behavior) = REQUIRED];
@@ -20634,7 +20634,7 @@ message AbandonInstancesRegionInstanceGroupManagerRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  RegionInstanceGroupManagersAbandonInstancesRequest region_instance_group_managers_abandon_instances_request_resource = 220064035 [(google.api.field_behavior) = REQUIRED];
+  RegionInstanceGroupManagersAbandonInstancesRequest region_instance_group_managers_abandon_instances_request_resource = 488499491 [(google.api.field_behavior) = REQUIRED];
 
   // An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed.
   //
@@ -20673,7 +20673,7 @@ message CreateInstancesRegionInstanceGroupManagerRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  RegionInstanceGroupManagersCreateInstancesRequest region_instance_group_managers_create_instances_request_resource = 90578824 [(google.api.field_behavior) = REQUIRED];
+  RegionInstanceGroupManagersCreateInstancesRequest region_instance_group_managers_create_instances_request_resource = 359014280 [(google.api.field_behavior) = REQUIRED];
 
   // An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed.
   //
@@ -20716,7 +20716,7 @@ message DeleteInstancesRegionInstanceGroupManagerRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  RegionInstanceGroupManagersDeleteInstancesRequest region_instance_group_managers_delete_instances_request_resource = 232441209 [(google.api.field_behavior) = REQUIRED];
+  RegionInstanceGroupManagersDeleteInstancesRequest region_instance_group_managers_delete_instances_request_resource = 500876665 [(google.api.field_behavior) = REQUIRED];
 
   // An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed.
   //
@@ -20785,7 +20785,7 @@ message ListRegionInstanceGroupManagersRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -20807,7 +20807,7 @@ message ListRegionInstanceGroupManagersRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -20820,7 +20820,7 @@ message ListErrorsRegionInstanceGroupManagersRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The name of the managed instance group. It must be a string that meets the requirements in RFC1035, or an unsigned long integer: must match regexp pattern: (?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)|[1-9][0-9]{0,19}.
   string instance_group_manager = 249363395 [(google.api.field_behavior) = REQUIRED];
@@ -20845,7 +20845,7 @@ message ListErrorsRegionInstanceGroupManagersRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -20858,7 +20858,7 @@ message ListManagedInstancesRegionInstanceGroupManagersRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The name of the managed instance group.
   string instance_group_manager = 249363395 [(google.api.field_behavior) = REQUIRED];
@@ -20883,7 +20883,7 @@ message ListManagedInstancesRegionInstanceGroupManagersRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -20896,7 +20896,7 @@ message ListPerInstanceConfigsRegionInstanceGroupManagersRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The name of the managed instance group. It should conform to RFC1035.
   string instance_group_manager = 249363395 [(google.api.field_behavior) = REQUIRED];
@@ -20921,7 +20921,7 @@ message ListPerInstanceConfigsRegionInstanceGroupManagersRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -21108,7 +21108,7 @@ message ListRegionInstanceGroupsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -21130,7 +21130,7 @@ message ListRegionInstanceGroupsRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -21143,7 +21143,7 @@ message ListInstancesRegionInstanceGroupsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Name of the regional instance group for which we want to list the instances.
   string instance_group = 81095253 [(google.api.field_behavior) = REQUIRED];
@@ -21171,7 +21171,7 @@ message ListInstancesRegionInstanceGroupsRequest {
   RegionInstanceGroupsListInstancesRequest region_instance_groups_list_instances_request_resource = 48239828 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -21201,7 +21201,7 @@ message SetNamedPortsRegionInstanceGroupRequest {
 // A request message for RegionNetworkEndpointGroups.Delete. See the method description for details.
 message DeleteRegionNetworkEndpointGroupRequest {
   // The name of the network endpoint group to delete. It should comply with RFC1035.
-  string network_endpoint_group = 165471622 [(google.api.field_behavior) = REQUIRED];
+  string network_endpoint_group = 433907078 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -21221,7 +21221,7 @@ message DeleteRegionNetworkEndpointGroupRequest {
 // A request message for RegionNetworkEndpointGroups.Get. See the method description for details.
 message GetRegionNetworkEndpointGroupRequest {
   // The name of the network endpoint group. It should comply with RFC1035.
-  string network_endpoint_group = 165471622 [(google.api.field_behavior) = REQUIRED];
+  string network_endpoint_group = 433907078 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -21234,7 +21234,7 @@ message GetRegionNetworkEndpointGroupRequest {
 // A request message for RegionNetworkEndpointGroups.Insert. See the method description for details.
 message InsertRegionNetworkEndpointGroupRequest {
   // The body resource for this request
-  NetworkEndpointGroup network_endpoint_group_resource = 257353383 [(google.api.field_behavior) = REQUIRED];
+  NetworkEndpointGroup network_endpoint_group_resource = 525788839 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -21260,7 +21260,7 @@ message ListRegionNetworkEndpointGroupsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -21282,14 +21282,14 @@ message ListRegionNetworkEndpointGroupsRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for RegionNotificationEndpoints.Delete. See the method description for details.
 message DeleteRegionNotificationEndpointRequest {
   // Name of the NotificationEndpoint resource to delete.
-  string notification_endpoint = 108371561 [(google.api.field_behavior) = REQUIRED];
+  string notification_endpoint = 376807017 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -21309,7 +21309,7 @@ message DeleteRegionNotificationEndpointRequest {
 // A request message for RegionNotificationEndpoints.Get. See the method description for details.
 message GetRegionNotificationEndpointRequest {
   // Name of the NotificationEndpoint resource to return.
-  string notification_endpoint = 108371561 [(google.api.field_behavior) = REQUIRED];
+  string notification_endpoint = 376807017 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -21322,7 +21322,7 @@ message GetRegionNotificationEndpointRequest {
 // A request message for RegionNotificationEndpoints.Insert. See the method description for details.
 message InsertRegionNotificationEndpointRequest {
   // The body resource for this request
-  NotificationEndpoint notification_endpoint_resource = 70024484 [(google.api.field_behavior) = REQUIRED];
+  NotificationEndpoint notification_endpoint_resource = 338459940 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -21348,7 +21348,7 @@ message ListRegionNotificationEndpointsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -21370,7 +21370,7 @@ message ListRegionNotificationEndpointsRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -21413,7 +21413,7 @@ message ListRegionOperationsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -21435,7 +21435,7 @@ message ListRegionOperationsRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -21514,7 +21514,7 @@ message ListRegionSslCertificatesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -21536,7 +21536,7 @@ message ListRegionSslCertificatesRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -21602,7 +21602,7 @@ message ListRegionTargetHttpProxiesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -21624,7 +21624,7 @@ message ListRegionTargetHttpProxiesRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -21647,7 +21647,7 @@ message SetUrlMapRegionTargetHttpProxyRequest {
   string target_http_proxy = 206872421 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  UrlMapReference url_map_reference_resource = 130265877 [(google.api.field_behavior) = REQUIRED];
+  UrlMapReference url_map_reference_resource = 398701333 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -21700,7 +21700,7 @@ message InsertRegionTargetHttpsProxyRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  TargetHttpsProxy target_https_proxy_resource = 165222017 [(google.api.field_behavior) = REQUIRED];
+  TargetHttpsProxy target_https_proxy_resource = 433657473 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -21713,7 +21713,7 @@ message ListRegionTargetHttpsProxiesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -21735,7 +21735,7 @@ message ListRegionTargetHttpsProxiesRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -21748,7 +21748,7 @@ message SetSslCertificatesRegionTargetHttpsProxyRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  RegionTargetHttpsProxiesSetSslCertificatesRequest region_target_https_proxies_set_ssl_certificates_request_resource = 122257927 [(google.api.field_behavior) = REQUIRED];
+  RegionTargetHttpsProxiesSetSslCertificatesRequest region_target_https_proxies_set_ssl_certificates_request_resource = 390693383 [(google.api.field_behavior) = REQUIRED];
 
   // An optional request ID to identify requests. Specify a unique request ID so that if you must retry your request, the server will know to ignore the request if it has already been completed.
   //
@@ -21781,7 +21781,7 @@ message SetUrlMapRegionTargetHttpsProxyRequest {
   string target_https_proxy = 52336748 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  UrlMapReference url_map_reference_resource = 130265877 [(google.api.field_behavior) = REQUIRED];
+  UrlMapReference url_map_reference_resource = 398701333 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -21797,7 +21797,7 @@ message DeleteRegionUrlMapRequest {
   optional string request_id = 37109963;
 
   // Name of the UrlMap resource to delete.
-  string url_map = 98585228 [(google.api.field_behavior) = REQUIRED];
+  string url_map = 367020684 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -21810,7 +21810,7 @@ message GetRegionUrlMapRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the UrlMap resource to return.
-  string url_map = 98585228 [(google.api.field_behavior) = REQUIRED];
+  string url_map = 367020684 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -21839,7 +21839,7 @@ message ListRegionUrlMapsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -21861,7 +21861,7 @@ message ListRegionUrlMapsRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -21877,7 +21877,7 @@ message PatchRegionUrlMapRequest {
   optional string request_id = 37109963;
 
   // Name of the UrlMap resource to patch.
-  string url_map = 98585228 [(google.api.field_behavior) = REQUIRED];
+  string url_map = 367020684 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   UrlMap url_map_resource = 168675425 [(google.api.field_behavior) = REQUIRED];
@@ -21896,7 +21896,7 @@ message UpdateRegionUrlMapRequest {
   optional string request_id = 37109963;
 
   // Name of the UrlMap resource to update.
-  string url_map = 98585228 [(google.api.field_behavior) = REQUIRED];
+  string url_map = 367020684 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   UrlMap url_map_resource = 168675425 [(google.api.field_behavior) = REQUIRED];
@@ -21915,7 +21915,7 @@ message ValidateRegionUrlMapRequest {
   RegionUrlMapsValidateRequest region_url_maps_validate_request_resource = 56632858 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the UrlMap resource to be validated as.
-  string url_map = 98585228 [(google.api.field_behavior) = REQUIRED];
+  string url_map = 367020684 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -21938,7 +21938,7 @@ message ListRegionsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -21957,7 +21957,7 @@ message ListRegionsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -21970,10 +21970,10 @@ message AggregatedListReservationsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -21992,7 +21992,7 @@ message AggregatedListReservationsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -22032,7 +22032,7 @@ message GetReservationRequest {
 // A request message for Reservations.GetIamPolicy. See the method description for details.
 message GetIamPolicyReservationRequest {
   // Requested IAM Policy version.
-  optional int32 options_requested_policy_version = 230784573;
+  optional int32 options_requested_policy_version = 499220029;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -22058,7 +22058,7 @@ message InsertReservationRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  Reservation reservation_resource = 16594721 [(google.api.field_behavior) = REQUIRED];
+  Reservation reservation_resource = 285030177 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -22074,7 +22074,7 @@ message ListReservationsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -22093,7 +22093,7 @@ message ListReservationsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // Name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -22116,7 +22116,7 @@ message ResizeReservationRequest {
   string reservation = 47530956 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  ReservationsResizeRequest reservations_resize_request_resource = 120827345 [(google.api.field_behavior) = REQUIRED];
+  ReservationsResizeRequest reservations_resize_request_resource = 389262801 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -22135,7 +22135,7 @@ message SetIamPolicyReservationRequest {
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  ZoneSetPolicyRequest zone_set_policy_request_resource = 113646651 [(google.api.field_behavior) = REQUIRED];
+  ZoneSetPolicyRequest zone_set_policy_request_resource = 382082107 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -22148,7 +22148,7 @@ message TestIamPermissionsReservationRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
   // The name of the zone for this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -22164,10 +22164,10 @@ message AggregatedListResourcePoliciesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -22186,7 +22186,7 @@ message AggregatedListResourcePoliciesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -22226,7 +22226,7 @@ message GetResourcePolicyRequest {
 // A request message for ResourcePolicies.GetIamPolicy. See the method description for details.
 message GetIamPolicyResourcePolicyRequest {
   // Requested IAM Policy version.
-  optional int32 options_requested_policy_version = 230784573;
+  optional int32 options_requested_policy_version = 499220029;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -22268,7 +22268,7 @@ message ListResourcePoliciesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -22290,7 +22290,7 @@ message ListResourcePoliciesRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -22303,7 +22303,7 @@ message SetIamPolicyResourcePolicyRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  RegionSetPolicyRequest region_set_policy_request_resource = 8053635 [(google.api.field_behavior) = REQUIRED];
+  RegionSetPolicyRequest region_set_policy_request_resource = 276489091 [(google.api.field_behavior) = REQUIRED];
 
   // Name or id of the resource for this request.
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
@@ -22322,7 +22322,7 @@ message TestIamPermissionsResourcePolicyRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -22335,10 +22335,10 @@ message AggregatedListRoutersRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -22357,7 +22357,7 @@ message AggregatedListRoutersRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -22403,7 +22403,7 @@ message GetNatMappingInfoRoutersRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -22425,7 +22425,7 @@ message GetNatMappingInfoRoutersRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // Name of the Router resource to query for Nat Mapping information of VM endpoints.
   string router = 148608841 [(google.api.field_behavior) = REQUIRED];
@@ -22474,7 +22474,7 @@ message ListRoutersRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -22496,7 +22496,7 @@ message ListRoutersRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -22615,7 +22615,7 @@ message ListRoutesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -22634,7 +22634,7 @@ message ListRoutesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -22647,7 +22647,7 @@ message AddRuleSecurityPolicyRequest {
   string security_policy = 171082513 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  SecurityPolicyRule security_policy_rule_resource = 134257987 [(google.api.field_behavior) = REQUIRED];
+  SecurityPolicyRule security_policy_rule_resource = 402693443 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -22681,7 +22681,7 @@ message GetSecurityPolicyRequest {
 // A request message for SecurityPolicies.GetRule. See the method description for details.
 message GetRuleSecurityPolicyRequest {
   // The priority of the rule to get from the security policy.
-  optional int32 priority = 176716196;
+  optional int32 priority = 445151652;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -22717,7 +22717,7 @@ message ListSecurityPoliciesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -22736,7 +22736,7 @@ message ListSecurityPoliciesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -22749,7 +22749,7 @@ message ListPreconfiguredExpressionSetsSecurityPoliciesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -22768,7 +22768,7 @@ message ListPreconfiguredExpressionSetsSecurityPoliciesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -22795,7 +22795,7 @@ message PatchSecurityPolicyRequest {
 // A request message for SecurityPolicies.PatchRule. See the method description for details.
 message PatchRuleSecurityPolicyRequest {
   // The priority of the rule to patch.
-  optional int32 priority = 176716196;
+  optional int32 priority = 445151652;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -22804,14 +22804,14 @@ message PatchRuleSecurityPolicyRequest {
   string security_policy = 171082513 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  SecurityPolicyRule security_policy_rule_resource = 134257987 [(google.api.field_behavior) = REQUIRED];
+  SecurityPolicyRule security_policy_rule_resource = 402693443 [(google.api.field_behavior) = REQUIRED];
 
 }
 
 // A request message for SecurityPolicies.RemoveRule. See the method description for details.
 message RemoveRuleSecurityPolicyRequest {
   // The priority of the rule to remove from the security policy.
-  optional int32 priority = 176716196;
+  optional int32 priority = 445151652;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -22834,7 +22834,7 @@ message DeleteSnapshotRequest {
   optional string request_id = 37109963;
 
   // Name of the Snapshot resource to delete.
-  string snapshot = 16438724 [(google.api.field_behavior) = REQUIRED];
+  string snapshot = 284874180 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -22844,14 +22844,14 @@ message GetSnapshotRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the Snapshot resource to return.
-  string snapshot = 16438724 [(google.api.field_behavior) = REQUIRED];
+  string snapshot = 284874180 [(google.api.field_behavior) = REQUIRED];
 
 }
 
 // A request message for Snapshots.GetIamPolicy. See the method description for details.
 message GetIamPolicySnapshotRequest {
   // Requested IAM Policy version.
-  optional int32 options_requested_policy_version = 230784573;
+  optional int32 options_requested_policy_version = 499220029;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -22870,7 +22870,7 @@ message ListSnapshotsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -22889,14 +22889,14 @@ message ListSnapshotsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for Snapshots.SetIamPolicy. See the method description for details.
 message SetIamPolicySnapshotRequest {
   // The body resource for this request
-  GlobalSetPolicyRequest global_set_policy_request_resource = 68613042 [(google.api.field_behavior) = REQUIRED];
+  GlobalSetPolicyRequest global_set_policy_request_resource = 337048498 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -22909,7 +22909,7 @@ message SetIamPolicySnapshotRequest {
 // A request message for Snapshots.SetLabels. See the method description for details.
 message SetLabelsSnapshotRequest {
   // The body resource for this request
-  GlobalSetLabelsRequest global_set_labels_request_resource = 51481733 [(google.api.field_behavior) = REQUIRED];
+  GlobalSetLabelsRequest global_set_labels_request_resource = 319917189 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -22928,7 +22928,7 @@ message TestIamPermissionsSnapshotRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -22941,10 +22941,10 @@ message AggregatedListSslCertificatesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -22963,7 +22963,7 @@ message AggregatedListSslCertificatesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -23020,7 +23020,7 @@ message ListSslCertificatesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -23039,7 +23039,7 @@ message ListSslCertificatesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -23056,7 +23056,7 @@ message DeleteSslPolicyRequest {
   optional string request_id = 37109963;
 
   // Name of the SSL policy to delete. The name must be 1-63 characters long, and comply with RFC1035.
-  string ssl_policy = 26754757 [(google.api.field_behavior) = REQUIRED];
+  string ssl_policy = 295190213 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -23066,7 +23066,7 @@ message GetSslPolicyRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the SSL policy to update. The name must be 1-63 characters long, and comply with RFC1035.
-  string ssl_policy = 26754757 [(google.api.field_behavior) = REQUIRED];
+  string ssl_policy = 295190213 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -23083,7 +23083,7 @@ message InsertSslPolicyRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  SslPolicy ssl_policy_resource = 6456392 [(google.api.field_behavior) = REQUIRED];
+  SslPolicy ssl_policy_resource = 274891848 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -23096,7 +23096,7 @@ message ListSslPoliciesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -23115,7 +23115,7 @@ message ListSslPoliciesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -23128,7 +23128,7 @@ message ListAvailableFeaturesSslPoliciesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -23147,7 +23147,7 @@ message ListAvailableFeaturesSslPoliciesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -23164,10 +23164,10 @@ message PatchSslPolicyRequest {
   optional string request_id = 37109963;
 
   // Name of the SSL policy to update. The name must be 1-63 characters long, and comply with RFC1035.
-  string ssl_policy = 26754757 [(google.api.field_behavior) = REQUIRED];
+  string ssl_policy = 295190213 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  SslPolicy ssl_policy_resource = 6456392 [(google.api.field_behavior) = REQUIRED];
+  SslPolicy ssl_policy_resource = 274891848 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -23180,10 +23180,10 @@ message AggregatedListSubnetworksRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -23202,7 +23202,7 @@ message AggregatedListSubnetworksRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -23222,7 +23222,7 @@ message DeleteSubnetworkRequest {
   optional string request_id = 37109963;
 
   // Name of the Subnetwork resource to delete.
-  string subnetwork = 39392238 [(google.api.field_behavior) = REQUIRED];
+  string subnetwork = 307827694 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -23242,10 +23242,10 @@ message ExpandIpCidrRangeSubnetworkRequest {
   optional string request_id = 37109963;
 
   // Name of the Subnetwork resource to update.
-  string subnetwork = 39392238 [(google.api.field_behavior) = REQUIRED];
+  string subnetwork = 307827694 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  SubnetworksExpandIpCidrRangeRequest subnetworks_expand_ip_cidr_range_request_resource = 208578654 [(google.api.field_behavior) = REQUIRED];
+  SubnetworksExpandIpCidrRangeRequest subnetworks_expand_ip_cidr_range_request_resource = 477014110 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -23258,14 +23258,14 @@ message GetSubnetworkRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the Subnetwork resource to return.
-  string subnetwork = 39392238 [(google.api.field_behavior) = REQUIRED];
+  string subnetwork = 307827694 [(google.api.field_behavior) = REQUIRED];
 
 }
 
 // A request message for Subnetworks.GetIamPolicy. See the method description for details.
 message GetIamPolicySubnetworkRequest {
   // Requested IAM Policy version.
-  optional int32 options_requested_policy_version = 230784573;
+  optional int32 options_requested_policy_version = 499220029;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -23307,7 +23307,7 @@ message ListSubnetworksRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -23329,7 +23329,7 @@ message ListSubnetworksRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -23342,7 +23342,7 @@ message ListUsableSubnetworksRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -23361,14 +23361,14 @@ message ListUsableSubnetworksRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
 // A request message for Subnetworks.Patch. See the method description for details.
 message PatchSubnetworkRequest {
   // The drain timeout specifies the upper bound in seconds on the amount of time allowed to drain connections from the current ACTIVE subnetwork to the current BACKUP subnetwork. The drain timeout is only applicable when the following conditions are true: - the subnetwork being patched has purpose = INTERNAL_HTTPS_LOAD_BALANCER - the subnetwork being patched has role = BACKUP - the patch request is setting the role to ACTIVE. Note that after this patch operation the roles of the ACTIVE and BACKUP subnetworks will be swapped.
-  optional int32 drain_timeout_seconds = 89271642;
+  optional int32 drain_timeout_seconds = 357707098;
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -23384,7 +23384,7 @@ message PatchSubnetworkRequest {
   optional string request_id = 37109963;
 
   // Name of the Subnetwork resource to patch.
-  string subnetwork = 39392238 [(google.api.field_behavior) = REQUIRED];
+  string subnetwork = 307827694 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   Subnetwork subnetwork_resource = 42233151 [(google.api.field_behavior) = REQUIRED];
@@ -23400,7 +23400,7 @@ message SetIamPolicySubnetworkRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  RegionSetPolicyRequest region_set_policy_request_resource = 8053635 [(google.api.field_behavior) = REQUIRED];
+  RegionSetPolicyRequest region_set_policy_request_resource = 276489091 [(google.api.field_behavior) = REQUIRED];
 
   // Name or id of the resource for this request.
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
@@ -23423,10 +23423,10 @@ message SetPrivateIpGoogleAccessSubnetworkRequest {
   optional string request_id = 37109963;
 
   // Name of the Subnetwork resource.
-  string subnetwork = 39392238 [(google.api.field_behavior) = REQUIRED];
+  string subnetwork = 307827694 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  SubnetworksSetPrivateIpGoogleAccessRequest subnetworks_set_private_ip_google_access_request_resource = 485240 [(google.api.field_behavior) = REQUIRED];
+  SubnetworksSetPrivateIpGoogleAccessRequest subnetworks_set_private_ip_google_access_request_resource = 268920696 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -23442,7 +23442,7 @@ message TestIamPermissionsSubnetworkRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -23486,7 +23486,7 @@ message InsertTargetGrpcProxyRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  TargetGrpcProxy target_grpc_proxy_resource = 60486994 [(google.api.field_behavior) = REQUIRED];
+  TargetGrpcProxy target_grpc_proxy_resource = 328922450 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -23499,7 +23499,7 @@ message ListTargetGrpcProxiesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -23518,7 +23518,7 @@ message ListTargetGrpcProxiesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -23538,7 +23538,7 @@ message PatchTargetGrpcProxyRequest {
   string target_grpc_proxy = 5020283 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TargetGrpcProxy target_grpc_proxy_resource = 60486994 [(google.api.field_behavior) = REQUIRED];
+  TargetGrpcProxy target_grpc_proxy_resource = 328922450 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -23551,10 +23551,10 @@ message AggregatedListTargetHttpProxiesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -23573,7 +23573,7 @@ message AggregatedListTargetHttpProxiesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -23630,7 +23630,7 @@ message ListTargetHttpProxiesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -23649,7 +23649,7 @@ message ListTargetHttpProxiesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -23689,7 +23689,7 @@ message SetUrlMapTargetHttpProxyRequest {
   string target_http_proxy = 206872421 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  UrlMapReference url_map_reference_resource = 130265877 [(google.api.field_behavior) = REQUIRED];
+  UrlMapReference url_map_reference_resource = 398701333 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -23702,10 +23702,10 @@ message AggregatedListTargetHttpsProxiesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -23724,7 +23724,7 @@ message AggregatedListTargetHttpsProxiesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -23768,7 +23768,7 @@ message InsertTargetHttpsProxyRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  TargetHttpsProxy target_https_proxy_resource = 165222017 [(google.api.field_behavior) = REQUIRED];
+  TargetHttpsProxy target_https_proxy_resource = 433657473 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -23781,7 +23781,7 @@ message ListTargetHttpsProxiesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -23800,7 +23800,7 @@ message ListTargetHttpsProxiesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -23880,7 +23880,7 @@ message SetUrlMapTargetHttpsProxyRequest {
   string target_https_proxy = 52336748 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  UrlMapReference url_map_reference_resource = 130265877 [(google.api.field_behavior) = REQUIRED];
+  UrlMapReference url_map_reference_resource = 398701333 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -23893,10 +23893,10 @@ message AggregatedListTargetInstancesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -23915,7 +23915,7 @@ message AggregatedListTargetInstancesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -23932,7 +23932,7 @@ message DeleteTargetInstanceRequest {
   optional string request_id = 37109963;
 
   // Name of the TargetInstance resource to delete.
-  string target_instance = 21333891 [(google.api.field_behavior) = REQUIRED];
+  string target_instance = 289769347 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the zone scoping this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -23945,7 +23945,7 @@ message GetTargetInstanceRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the TargetInstance resource to return.
-  string target_instance = 21333891 [(google.api.field_behavior) = REQUIRED];
+  string target_instance = 289769347 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the zone scoping this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -23965,7 +23965,7 @@ message InsertTargetInstanceRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  TargetInstance target_instance_resource = 162017610 [(google.api.field_behavior) = REQUIRED];
+  TargetInstance target_instance_resource = 430453066 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the zone scoping this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -23981,7 +23981,7 @@ message ListTargetInstancesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -24000,7 +24000,7 @@ message ListTargetInstancesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // Name of the zone scoping this request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -24026,7 +24026,7 @@ message AddHealthCheckTargetPoolRequest {
   string target_pool = 62796298 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TargetPoolsAddHealthCheckRequest target_pools_add_health_check_request_resource = 1137956 [(google.api.field_behavior) = REQUIRED];
+  TargetPoolsAddHealthCheckRequest target_pools_add_health_check_request_resource = 269573412 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24049,7 +24049,7 @@ message AddInstanceTargetPoolRequest {
   string target_pool = 62796298 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TargetPoolsAddInstanceRequest target_pools_add_instance_request_resource = 160360948 [(google.api.field_behavior) = REQUIRED];
+  TargetPoolsAddInstanceRequest target_pools_add_instance_request_resource = 428796404 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24062,10 +24062,10 @@ message AggregatedListTargetPoolsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -24084,7 +24084,7 @@ message AggregatedListTargetPoolsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -24124,7 +24124,7 @@ message GetTargetPoolRequest {
 // A request message for TargetPools.GetHealth. See the method description for details.
 message GetHealthTargetPoolRequest {
   // The body resource for this request
-  InstanceReference instance_reference_resource = 24490604 [(google.api.field_behavior) = REQUIRED];
+  InstanceReference instance_reference_resource = 292926060 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -24166,7 +24166,7 @@ message ListTargetPoolsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -24188,7 +24188,7 @@ message ListTargetPoolsRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -24211,7 +24211,7 @@ message RemoveHealthCheckTargetPoolRequest {
   string target_pool = 62796298 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TargetPoolsRemoveHealthCheckRequest target_pools_remove_health_check_request_resource = 36549555 [(google.api.field_behavior) = REQUIRED];
+  TargetPoolsRemoveHealthCheckRequest target_pools_remove_health_check_request_resource = 304985011 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24260,7 +24260,7 @@ message SetBackupTargetPoolRequest {
   string target_pool = 62796298 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TargetReference target_reference_resource = 255286256 [(google.api.field_behavior) = REQUIRED];
+  TargetReference target_reference_resource = 523721712 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24277,7 +24277,7 @@ message DeleteTargetSslProxyRequest {
   optional string request_id = 37109963;
 
   // Name of the TargetSslProxy resource to delete.
-  string target_ssl_proxy = 70360397 [(google.api.field_behavior) = REQUIRED];
+  string target_ssl_proxy = 338795853 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24287,7 +24287,7 @@ message GetTargetSslProxyRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the TargetSslProxy resource to return.
-  string target_ssl_proxy = 70360397 [(google.api.field_behavior) = REQUIRED];
+  string target_ssl_proxy = 338795853 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24317,7 +24317,7 @@ message ListTargetSslProxiesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -24336,7 +24336,7 @@ message ListTargetSslProxiesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -24356,7 +24356,7 @@ message SetBackendServiceTargetSslProxyRequest {
   TargetSslProxiesSetBackendServiceRequest target_ssl_proxies_set_backend_service_request_resource = 139080868 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the TargetSslProxy resource whose BackendService resource is to be set.
-  string target_ssl_proxy = 70360397 [(google.api.field_behavior) = REQUIRED];
+  string target_ssl_proxy = 338795853 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24376,7 +24376,7 @@ message SetProxyHeaderTargetSslProxyRequest {
   TargetSslProxiesSetProxyHeaderRequest target_ssl_proxies_set_proxy_header_request_resource = 205284526 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the TargetSslProxy resource whose ProxyHeader is to be set.
-  string target_ssl_proxy = 70360397 [(google.api.field_behavior) = REQUIRED];
+  string target_ssl_proxy = 338795853 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24396,7 +24396,7 @@ message SetSslCertificatesTargetSslProxyRequest {
   TargetSslProxiesSetSslCertificatesRequest target_ssl_proxies_set_ssl_certificates_request_resource = 147940797 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the TargetSslProxy resource whose SslCertificate resource is to be set.
-  string target_ssl_proxy = 70360397 [(google.api.field_behavior) = REQUIRED];
+  string target_ssl_proxy = 338795853 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24416,7 +24416,7 @@ message SetSslPolicyTargetSslProxyRequest {
   SslPolicyReference ssl_policy_reference_resource = 235403836 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the TargetSslProxy resource whose SSL policy is to be set. The name must be 1-63 characters long, and comply with RFC1035.
-  string target_ssl_proxy = 70360397 [(google.api.field_behavior) = REQUIRED];
+  string target_ssl_proxy = 338795853 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24433,7 +24433,7 @@ message DeleteTargetTcpProxyRequest {
   optional string request_id = 37109963;
 
   // Name of the TargetTcpProxy resource to delete.
-  string target_tcp_proxy = 234629986 [(google.api.field_behavior) = REQUIRED];
+  string target_tcp_proxy = 503065442 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24443,7 +24443,7 @@ message GetTargetTcpProxyRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the TargetTcpProxy resource to return.
-  string target_tcp_proxy = 234629986 [(google.api.field_behavior) = REQUIRED];
+  string target_tcp_proxy = 503065442 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24473,7 +24473,7 @@ message ListTargetTcpProxiesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -24492,7 +24492,7 @@ message ListTargetTcpProxiesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -24509,10 +24509,10 @@ message SetBackendServiceTargetTcpProxyRequest {
   optional string request_id = 37109963;
 
   // The body resource for this request
-  TargetTcpProxiesSetBackendServiceRequest target_tcp_proxies_set_backend_service_request_resource = 5286127 [(google.api.field_behavior) = REQUIRED];
+  TargetTcpProxiesSetBackendServiceRequest target_tcp_proxies_set_backend_service_request_resource = 273721583 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the TargetTcpProxy resource whose BackendService resource is to be set.
-  string target_tcp_proxy = 234629986 [(google.api.field_behavior) = REQUIRED];
+  string target_tcp_proxy = 503065442 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24532,7 +24532,7 @@ message SetProxyHeaderTargetTcpProxyRequest {
   TargetTcpProxiesSetProxyHeaderRequest target_tcp_proxies_set_proxy_header_request_resource = 219958339 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the TargetTcpProxy resource whose ProxyHeader is to be set.
-  string target_tcp_proxy = 234629986 [(google.api.field_behavior) = REQUIRED];
+  string target_tcp_proxy = 503065442 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24545,10 +24545,10 @@ message AggregatedListTargetVpnGatewaysRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -24567,7 +24567,7 @@ message AggregatedListTargetVpnGatewaysRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -24587,7 +24587,7 @@ message DeleteTargetVpnGatewayRequest {
   optional string request_id = 37109963;
 
   // Name of the target VPN gateway to delete.
-  string target_vpn_gateway = 264077387 [(google.api.field_behavior) = REQUIRED];
+  string target_vpn_gateway = 532512843 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24600,7 +24600,7 @@ message GetTargetVpnGatewayRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the target VPN gateway to return.
-  string target_vpn_gateway = 264077387 [(google.api.field_behavior) = REQUIRED];
+  string target_vpn_gateway = 532512843 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24633,7 +24633,7 @@ message ListTargetVpnGatewaysRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -24655,7 +24655,7 @@ message ListTargetVpnGatewaysRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -24668,10 +24668,10 @@ message AggregatedListUrlMapsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -24690,7 +24690,7 @@ message AggregatedListUrlMapsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -24707,7 +24707,7 @@ message DeleteUrlMapRequest {
   optional string request_id = 37109963;
 
   // Name of the UrlMap resource to delete.
-  string url_map = 98585228 [(google.api.field_behavior) = REQUIRED];
+  string url_map = 367020684 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24717,7 +24717,7 @@ message GetUrlMapRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the UrlMap resource to return.
-  string url_map = 98585228 [(google.api.field_behavior) = REQUIRED];
+  string url_map = 367020684 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24741,7 +24741,7 @@ message InsertUrlMapRequest {
 // A request message for UrlMaps.InvalidateCache. See the method description for details.
 message InvalidateCacheUrlMapRequest {
   // The body resource for this request
-  CacheInvalidationRule cache_invalidation_rule_resource = 44360109 [(google.api.field_behavior) = REQUIRED];
+  CacheInvalidationRule cache_invalidation_rule_resource = 312795565 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -24754,7 +24754,7 @@ message InvalidateCacheUrlMapRequest {
   optional string request_id = 37109963;
 
   // Name of the UrlMap scoping this request.
-  string url_map = 98585228 [(google.api.field_behavior) = REQUIRED];
+  string url_map = 367020684 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24767,7 +24767,7 @@ message ListUrlMapsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -24786,7 +24786,7 @@ message ListUrlMapsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -24803,7 +24803,7 @@ message PatchUrlMapRequest {
   optional string request_id = 37109963;
 
   // Name of the UrlMap resource to patch.
-  string url_map = 98585228 [(google.api.field_behavior) = REQUIRED];
+  string url_map = 367020684 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   UrlMap url_map_resource = 168675425 [(google.api.field_behavior) = REQUIRED];
@@ -24823,7 +24823,7 @@ message UpdateUrlMapRequest {
   optional string request_id = 37109963;
 
   // Name of the UrlMap resource to update.
-  string url_map = 98585228 [(google.api.field_behavior) = REQUIRED];
+  string url_map = 367020684 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
   UrlMap url_map_resource = 168675425 [(google.api.field_behavior) = REQUIRED];
@@ -24836,10 +24836,10 @@ message ValidateUrlMapRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the UrlMap resource to be validated as.
-  string url_map = 98585228 [(google.api.field_behavior) = REQUIRED];
+  string url_map = 367020684 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  UrlMapsValidateRequest url_maps_validate_request_resource = 127477999 [(google.api.field_behavior) = REQUIRED];
+  UrlMapsValidateRequest url_maps_validate_request_resource = 395913455 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24852,10 +24852,10 @@ message AggregatedListVpnGatewaysRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -24874,7 +24874,7 @@ message AggregatedListVpnGatewaysRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -24894,7 +24894,7 @@ message DeleteVpnGatewayRequest {
   optional string request_id = 37109963;
 
   // Name of the VPN gateway to delete.
-  string vpn_gateway = 138248697 [(google.api.field_behavior) = REQUIRED];
+  string vpn_gateway = 406684153 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24907,7 +24907,7 @@ message GetVpnGatewayRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the VPN gateway to return.
-  string vpn_gateway = 138248697 [(google.api.field_behavior) = REQUIRED];
+  string vpn_gateway = 406684153 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24920,7 +24920,7 @@ message GetStatusVpnGatewayRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Name of the VPN gateway to return.
-  string vpn_gateway = 138248697 [(google.api.field_behavior) = REQUIRED];
+  string vpn_gateway = 406684153 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -24953,7 +24953,7 @@ message ListVpnGatewaysRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -24975,7 +24975,7 @@ message ListVpnGatewaysRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -25014,7 +25014,7 @@ message TestIamPermissionsVpnGatewayRequest {
   string resource = 195806222 [(google.api.field_behavior) = REQUIRED];
 
   // The body resource for this request
-  TestPermissionsRequest test_permissions_request_resource = 170779302 [(google.api.field_behavior) = REQUIRED];
+  TestPermissionsRequest test_permissions_request_resource = 439214758 [(google.api.field_behavior) = REQUIRED];
 
 }
 
@@ -25027,10 +25027,10 @@ message AggregatedListVpnTunnelsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -25049,7 +25049,7 @@ message AggregatedListVpnTunnelsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -25115,7 +25115,7 @@ message ListVpnTunnelsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -25137,7 +25137,7 @@ message ListVpnTunnelsRequest {
   string region = 138946292 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 
@@ -25180,7 +25180,7 @@ message ListZoneOperationsRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -25199,7 +25199,7 @@ message ListZoneOperationsRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
   // Name of the zone for request.
   string zone = 3744684 [(google.api.field_behavior) = REQUIRED];
@@ -25238,7 +25238,7 @@ message ListZonesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -25257,7 +25257,7 @@ message ListZonesRequest {
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
 
   // Opt-in for partial success behavior which provides partial results in case of failure. The default value is false and the logic is the same as today.
-  optional bool return_partial_success = 248762934;
+  optional bool return_partial_success = 517198390;
 
 }
 

--- a/google/cloud/compute/v1/compute_small.proto
+++ b/google/cloud/compute/v1/compute_small.proto
@@ -49,17 +49,17 @@ message Errors {
   optional string code = 3059181;
 
   // [Output Only] Indicates the field in the request that caused the error. This property is optional.
-  optional string location = 21995445;
+  optional string location = 290430901;
 
   // [Output Only] An optional, human-readable error message.
-  optional string message = 149618695;
+  optional string message = 418054151;
 
 }
 
 // [Output Only] If errors are generated during processing of the operation, this field will be populated.
 message Error {
   // [Output Only] The array of errors encountered while processing this operation.
-  repeated Errors errors = 47542123;
+  repeated Errors errors = 315977579;
 
 }
 
@@ -82,31 +82,31 @@ message Warnings {
 
     CLEANUP_FAILED = 150308440;
 
-    DEPRECATED_RESOURCE_USED = 123400130;
+    DEPRECATED_RESOURCE_USED = 391835586;
 
-    DEPRECATED_TYPE_USED = 78090774;
+    DEPRECATED_TYPE_USED = 346526230;
 
-    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 101007511;
+    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 369442967;
 
-    EXPERIMENTAL_TYPE_USED = 183518987;
+    EXPERIMENTAL_TYPE_USED = 451954443;
 
     EXTERNAL_API_WARNING = 175546307;
 
-    FIELD_VALUE_OVERRIDEN = 61233967;
+    FIELD_VALUE_OVERRIDEN = 329669423;
 
-    INJECTED_KERNELS_DEPRECATED = 148941963;
+    INJECTED_KERNELS_DEPRECATED = 417377419;
 
-    MISSING_TYPE_DEPENDENCY = 76070007;
+    MISSING_TYPE_DEPENDENCY = 344505463;
 
-    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 56529543;
+    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 324964999;
 
-    NEXT_HOP_CANNOT_IP_FORWARD = 114947431;
+    NEXT_HOP_CANNOT_IP_FORWARD = 383382887;
 
-    NEXT_HOP_INSTANCE_NOT_FOUND = 195814990;
+    NEXT_HOP_INSTANCE_NOT_FOUND = 464250446;
 
     NEXT_HOP_INSTANCE_NOT_ON_NETWORK = 243758146;
 
-    NEXT_HOP_NOT_RUNNING = 148645809;
+    NEXT_HOP_NOT_RUNNING = 417081265;
 
     NOT_CRITICAL_ERROR = 105763924;
 
@@ -114,15 +114,15 @@ message Warnings {
 
     REQUIRED_TOS_AGREEMENT = 3745539;
 
-    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 228293185;
+    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 496728641;
 
     RESOURCE_NOT_DELETED = 168598460;
 
-    SCHEMA_VALIDATION_IGNORED = 6810186;
+    SCHEMA_VALIDATION_IGNORED = 275245642;
 
     SINGLE_INSTANCE_PROPERTY_TEMPLATE = 268305617;
 
-    UNDECLARED_PROPERTIES = 122077983;
+    UNDECLARED_PROPERTIES = 390513439;
 
     UNREACHABLE = 13328052;
 
@@ -136,7 +136,7 @@ message Warnings {
   repeated Data data = 3076010;
 
   // [Output Only] A human-readable description of the warning code.
-  optional string message = 149618695;
+  optional string message = 418054151;
 
 }
 
@@ -169,13 +169,13 @@ message Operation {
   }
 
   // [Output Only] The value of `requestId` if you provided it in the request. Not present otherwise.
-  optional string client_operation_id = 28804839;
+  optional string client_operation_id = 297240295;
 
   // [Deprecated] This field is deprecated.
   optional string creation_timestamp = 30525366;
 
   // [Output Only] A textual description of the operation, which is set when the operation is created.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The time that this operation was completed. This value is in RFC3339 text format.
   optional string end_time = 114938801;
@@ -187,13 +187,13 @@ message Operation {
   optional string http_error_message = 202521945;
 
   // [Output Only] If the operation fails, this field contains the HTTP error status code that was returned. For example, a 404 means the resource was not found.
-  optional int32 http_error_status_code = 43909740;
+  optional int32 http_error_status_code = 312345196;
 
   // [Output Only] The unique identifier for the operation. This identifier is defined by the server.
   optional string id = 3355;
 
   // [Output Only] The time that this operation was requested. This value is in RFC3339 text format.
-  optional string insert_time = 165287059;
+  optional string insert_time = 433722515;
 
   // [Output Only] Type of the resource. Always compute#operation for Operation resources.
   optional string kind = 3292052;
@@ -211,7 +211,7 @@ message Operation {
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The time that this operation was started by the server. This value is in RFC3339 text format.
   optional string start_time = 37467274;
@@ -220,7 +220,7 @@ message Operation {
   optional Status status = 181260274;
 
   // [Output Only] An optional textual description of the current status of the operation.
-  optional string status_message = 28992698;
+  optional string status_message = 297428154;
 
   // [Output Only] The unique target ID, which identifies a specific incarnation of the target resource.
   optional string target_id = 258165385;
@@ -232,7 +232,7 @@ message Operation {
   optional string user = 3599307;
 
   // [Output Only] If warning messages are generated during processing of the operation, this field will be populated.
-  repeated Warnings warnings = 229655639;
+  repeated Warnings warnings = 498091095;
 
   // [Output Only] The URL of the zone where the operation resides. Only applicable when performing per-zone operations.
   optional string zone = 3744684;
@@ -262,7 +262,7 @@ message Address {
 
     EXTERNAL = 35607499;
 
-    INTERNAL = 10860221;
+    INTERNAL = 279295677;
 
     UNSPECIFIED_TYPE = 53933922;
 
@@ -288,9 +288,9 @@ message Address {
     // A value indicating that the enum field is not set.
     UNDEFINED_NETWORK_TIER = 0;
 
-    PREMIUM = 131095095;
+    PREMIUM = 399530551;
 
-    STANDARD = 216207037;
+    STANDARD = 484642493;
 
   }
 
@@ -303,13 +303,13 @@ message Address {
     // A value indicating that the enum field is not set.
     UNDEFINED_PURPOSE = 0;
 
-    DNS_RESOLVER = 207679100;
+    DNS_RESOLVER = 476114556;
 
     GCE_ENDPOINT = 230515243;
 
     NAT_AUTO = 163666477;
 
-    VPC_PEERING = 132364714;
+    VPC_PEERING = 400800170;
 
   }
 
@@ -320,14 +320,14 @@ message Address {
 
     IN_USE = 17393485;
 
-    RESERVED = 163805992;
+    RESERVED = 432241448;
 
-    RESERVING = 246151769;
+    RESERVING = 514587225;
 
   }
 
   // The static IP address represented by this resource.
-  optional string address = 194485236;
+  optional string address = 462920692;
 
   // The type of address to reserve, either INTERNAL or EXTERNAL. If unspecified, defaults to EXTERNAL.
   optional AddressType address_type = 264307877;
@@ -336,13 +336,13 @@ message Address {
   optional string creation_timestamp = 30525366;
 
   // An optional description of this resource. Provide this field when you create the resource.
-  optional string description = 154502140;
+  optional string description = 422937596;
 
   // [Output Only] The unique identifier for the resource. This identifier is defined by the server.
   optional string id = 3355;
 
   // The IP version that will be used by this address. Valid options are IPV4 or IPV6. This can only be specified for a global address.
-  optional IpVersion ip_version = 26524096;
+  optional IpVersion ip_version = 294959552;
 
   // [Output Only] Type of the resource. Always compute#address for addresses.
   optional string kind = 3292052;
@@ -356,29 +356,29 @@ message Address {
   // This signifies the networking tier used for configuring this address and can only take the following values: PREMIUM or STANDARD. Global forwarding rules can only be Premium Tier. Regional forwarding rules can be either Premium or Standard Tier. Standard Tier addresses applied to regional forwarding rules can be used with any external load balancer. Regional forwarding rules in Premium Tier can only be used with a network load balancer.
   //
   // If this field is not specified, it is assumed to be PREMIUM.
-  optional NetworkTier network_tier = 248962387;
+  optional NetworkTier network_tier = 517397843;
 
   // The prefix length if the resource reprensents an IP range.
-  optional int32 prefix_length = 185130291;
+  optional int32 prefix_length = 453565747;
 
   // The purpose of this resource, which can be one of the following values:
   // - `GCE_ENDPOINT` for addresses that are used by VM instances, alias IP ranges, internal load balancers, and similar resources.
   // - `DNS_RESOLVER` for a DNS resolver address in a subnetwork
   // - `VPC_PEERING` for addresses that are reserved for VPC peer networks.
   // - `NAT_AUTO` for addresses that are external IP addresses automatically reserved for Cloud NAT.
-  optional Purpose purpose = 47971614;
+  optional Purpose purpose = 316407070;
 
   // [Output Only] The URL of the region where the regional address resides. This field is not applicable to global addresses. You must specify this field as part of the HTTP request URL.
   optional string region = 138946292;
 
   // [Output Only] Server-defined URL for the resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] The status of the address, which can be one of RESERVING, RESERVED, or IN_USE. An address that is RESERVING is currently in the process of being reserved. A RESERVED address is currently reserved and available to use. An IN_USE address is currently being used by another resource and is not available.
   optional Status status = 181260274;
 
   // The URL of the subnetwork in which to reserve the address. If an IP address is specified, it must be within the subnetwork's IP range. This field can only be used with INTERNAL type with a GCE_ENDPOINT or DNS_RESOLVER purpose.
-  optional string subnetwork = 39392238;
+  optional string subnetwork = 307827694;
 
   // [Output Only] The URLs of the resources that are using this address.
   repeated string users = 111578632;
@@ -388,7 +388,7 @@ message Address {
 //
 message AddressesScopedList {
   // [Output Only] A list of addresses contained in this scope.
-  repeated Address addresses = 69237666;
+  repeated Address addresses = 337673122;
 
   // [Output Only] Informational warning which replaces the list of addresses when the list is empty.
   optional Warning warning = 50704284;
@@ -404,31 +404,31 @@ message Warning {
 
     CLEANUP_FAILED = 150308440;
 
-    DEPRECATED_RESOURCE_USED = 123400130;
+    DEPRECATED_RESOURCE_USED = 391835586;
 
-    DEPRECATED_TYPE_USED = 78090774;
+    DEPRECATED_TYPE_USED = 346526230;
 
-    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 101007511;
+    DISK_SIZE_LARGER_THAN_IMAGE_SIZE = 369442967;
 
-    EXPERIMENTAL_TYPE_USED = 183518987;
+    EXPERIMENTAL_TYPE_USED = 451954443;
 
     EXTERNAL_API_WARNING = 175546307;
 
-    FIELD_VALUE_OVERRIDEN = 61233967;
+    FIELD_VALUE_OVERRIDEN = 329669423;
 
-    INJECTED_KERNELS_DEPRECATED = 148941963;
+    INJECTED_KERNELS_DEPRECATED = 417377419;
 
-    MISSING_TYPE_DEPENDENCY = 76070007;
+    MISSING_TYPE_DEPENDENCY = 344505463;
 
-    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 56529543;
+    NEXT_HOP_ADDRESS_NOT_ASSIGNED = 324964999;
 
-    NEXT_HOP_CANNOT_IP_FORWARD = 114947431;
+    NEXT_HOP_CANNOT_IP_FORWARD = 383382887;
 
-    NEXT_HOP_INSTANCE_NOT_FOUND = 195814990;
+    NEXT_HOP_INSTANCE_NOT_FOUND = 464250446;
 
     NEXT_HOP_INSTANCE_NOT_ON_NETWORK = 243758146;
 
-    NEXT_HOP_NOT_RUNNING = 148645809;
+    NEXT_HOP_NOT_RUNNING = 417081265;
 
     NOT_CRITICAL_ERROR = 105763924;
 
@@ -436,15 +436,15 @@ message Warning {
 
     REQUIRED_TOS_AGREEMENT = 3745539;
 
-    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 228293185;
+    RESOURCE_IN_USE_BY_OTHER_RESOURCE_WARNING = 496728641;
 
     RESOURCE_NOT_DELETED = 168598460;
 
-    SCHEMA_VALIDATION_IGNORED = 6810186;
+    SCHEMA_VALIDATION_IGNORED = 275245642;
 
     SINGLE_INSTANCE_PROPERTY_TEMPLATE = 268305617;
 
-    UNDECLARED_PROPERTIES = 122077983;
+    UNDECLARED_PROPERTIES = 390513439;
 
     UNREACHABLE = 13328052;
 
@@ -458,7 +458,7 @@ message Warning {
   repeated Data data = 3076010;
 
   // [Output Only] A human-readable description of the warning code.
-  optional string message = 149618695;
+  optional string message = 418054151;
 
 }
 
@@ -477,7 +477,7 @@ message AddressAggregatedList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -499,7 +499,7 @@ message AddressList {
   optional string next_page_token = 79797525;
 
   // [Output Only] Server-defined URL for this resource.
-  optional string self_link = 187779341;
+  optional string self_link = 456214797;
 
   // [Output Only] Informational warning message.
   optional Warning warning = 50704284;
@@ -515,10 +515,10 @@ message AggregatedListAddressesRequest {
   // You can also filter nested fields. For example, you could specify `scheduling.automaticRestart = false` to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example: ``` (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake") ``` By default, each expression is an `AND` expression. However, you can include `AND` and `OR` expressions explicitly. For example: ``` (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true) ```
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // Indicates whether every visible scope for each scope type (zone, region, global) should be included in the response. For new resource types added after this field, the flag has no effect as new resource types will always include every visible scope for each scope type in response. For resource types which predate this field, if this flag is omitted or false, only scopes of the scope types where the resource type is expected to be found will be included.
-  optional bool include_all_scopes = 122892532;
+  optional bool include_all_scopes = 391327988;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than `maxResults`, Compute Engine returns a `nextPageToken` that can be used to get the next page of results in subsequent list requests. Acceptable values are `0` to `500`, inclusive. (Default: `500`)
   optional uint32 max_results = 54715419;
@@ -541,7 +541,7 @@ message AggregatedListAddressesRequest {
 // A request message for Addresses.Delete. See the method description for details.
 message DeleteAddressRequest {
   // Name of the address resource to delete.
-  string address = 194485236 [(google.api.field_behavior) = REQUIRED];
+  string address = 462920692 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -561,7 +561,7 @@ message DeleteAddressRequest {
 // A request message for Addresses.Insert. See the method description for details.
 message InsertAddressRequest {
   // The body resource for this request
-  Address address_resource = 215452665 [(google.api.field_behavior) = REQUIRED];
+  Address address_resource = 483888121 [(google.api.field_behavior) = REQUIRED];
 
   // Project ID for this request.
   string project = 227560217 [(google.api.field_behavior) = REQUIRED];
@@ -587,7 +587,7 @@ message ListAddressesRequest {
   // You can also filter nested fields. For example, you could specify scheduling.automaticRestart = false to include instances only if they are not scheduled for automatic restarts. You can use filtering on nested fields to filter based on resource labels.
   //
   // To filter on multiple expressions, provide each separate expression within parentheses. For example, (scheduling.automaticRestart = true) (cpuPlatform = "Intel Skylake"). By default, each expression is an AND expression. However, you can include AND and OR expressions explicitly. For example, (cpuPlatform = "Intel Skylake") OR (cpuPlatform = "Intel Broadwell") AND (scheduling.automaticRestart = true).
-  optional string filter = 67685240;
+  optional string filter = 336120696;
 
   // The maximum number of results per page that should be returned. If the number of available results is larger than maxResults, Compute Engine returns a nextPageToken that can be used to get the next page of results in subsequent list requests. Acceptable values are 0 to 500, inclusive. (Default: 500)
   optional uint32 max_results = 54715419;


### PR DESCRIPTION
This is a rollback of https://github.com/googleapis/disco-to-proto3-converter/pull/16, which became possible after protobuf fixed the original issue https://github.com/protocolbuffers/protobuf/issues/8114