### PR TITLE
chore: Update gapic-generator-python to 0.46.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -273,8 +273,8 @@ pip_repositories()
 
 http_archive(
     name = "gapic_generator_python",
-    strip_prefix = "gapic-generator-python-0.44.0",
-    urls = ["https://github.com/googleapis/gapic-generator-python/archive/v0.44.0.zip"],
+    strip_prefix = "gapic-generator-python-0.46.1",
+    urls = ["https://github.com/googleapis/gapic-generator-python/archive/v0.46.1.zip"],
 )
 
 load(


### PR DESCRIPTION
This is a resubmit of an already approved https://github.com/googleapis/googleapis-discovery/pull/36, which was closed without merging by mistake