### PR TITLE
chore: use gapic-generator-python 0.48.0

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -273,8 +273,8 @@ pip_repositories()
 
 http_archive(
     name = "gapic_generator_python",
-    strip_prefix = "gapic-generator-python-0.46.1",
-    urls = ["https://github.com/googleapis/gapic-generator-python/archive/v0.46.1.zip"],
+    strip_prefix = "gapic-generator-python-0.48.0",
+    urls = ["https://github.com/googleapis/gapic-generator-python/archive/v0.48.0.zip"],
 )
 
 load(


### PR DESCRIPTION
chore: add x-goog-api-client header to rest clients

feat: Raise GoogleAPICallError on REST response errors

feat: remove support for google-api-core < 1.26.0