### PR TITLE
fix(monolith): Bump microgenerator versions to monolith removal

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,8 +4,8 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "com_google_googleapis",
-    strip_prefix = "googleapis-f5ce261910c373fdd96bdaa47173f5604562876f",
-    urls = ["https://github.com/googleapis/googleapis/archive/f5ce261910c373fdd96bdaa47173f5604562876f.zip"],
+    strip_prefix = "googleapis-dba65e3c28aa8e26c4d5b8ec9c80fbd0d0f29864",
+    urls = ["https://github.com/googleapis/googleapis/archive/dba65e3c28aa8e26c4d5b8ec9c80fbd0d0f29864.zip"],
 )
 
 ##############################################################################
@@ -173,7 +173,7 @@ apple_support_dependencies()
 ##############################################################################
 # Java
 ##############################################################################
-_gax_java_version = "1.64.0"
+_gax_java_version = "1.65.1"
 
 http_archive(
     name = "com_google_api_gax_java",
@@ -198,7 +198,7 @@ grpc_java_repositories()
 
 # Java microgenerator.
 # Must go AFTER java-gax, since both java gax and gapic-generator are written in java and may conflict.
-_gapic_generator_java_version = "1.0.11"
+_gapic_generator_java_version = "1.0.13"
 
 http_archive(
     name = "gapic_generator_java",
@@ -274,8 +274,8 @@ pip_repositories()
 
 http_archive(
     name = "gapic_generator_python",
-    strip_prefix = "gapic-generator-python-0.48.0",
-    urls = ["https://github.com/googleapis/gapic-generator-python/archive/v0.48.0.zip"],
+    strip_prefix = "gapic-generator-python-0.50.0",
+    urls = ["https://github.com/googleapis/gapic-generator-python/archive/v0.50.0.zip"],
 )
 
 load(
@@ -312,9 +312,9 @@ go_gapic_repositories()
 # TypeScript
 ##############################################################################
 
-_gapic_generator_typescript_version = "1.4.0"
+_gapic_generator_typescript_version = "1.5.0"
 
-_gapic_generator_typescript_sha256 = "34718494b0696706ccfa46c8ed360f1999d7e33d5121aa86bb302af402b72d46"
+_gapic_generator_typescript_sha256 = "17e9387f3d6da8e5382b4e138ccc401137d2938b394040984ef2ca11ff9f8aea"
 
 ### TypeScript generator
 http_archive(
@@ -344,11 +344,11 @@ yarn_install(
 # PHP
 ##############################################################################
 
-load("@com_google_api_codegen//rules_gapic/php:php_gapic_repositories.bzl", "php", "php_gapic_repositories")
+load("@rules_gapic//php:php_gapic_repositories.bzl", "php", "php_gapic_repositories")
 
 php(
     name = "php",
-    prebuilt_phps = ["@com_google_api_codegen//rules_gapic/php:resources/php-7.1.30_linux_x86_64.tar.gz"],
+    prebuilt_phps = ["@rules_gapic//php:resources/php-7.1.30_linux_x86_64.tar.gz"],
     strip_prefix = "php-7.1.30",
     urls = ["https://www.php.net/distributions/php-7.1.30.tar.gz"],
 )
@@ -356,7 +356,7 @@ php(
 php_gapic_repositories()
 
 # PHP micro-generator (beta)
-_gapic_generator_php_version = "0.1.7"
+_gapic_generator_php_version = "1.0.2"
 
 http_archive(
     name = "gapic_generator_php",
@@ -385,9 +385,9 @@ http_archive(
     urls = ["https://github.com/googleapis/gax-dotnet/archive/refs/tags/%s.tar.gz" % _gax_dotnet_version],
 )
 
-_gapic_generator_csharp_version = "1.3.6"
+_gapic_generator_csharp_version = "1.3.7"
 
-_gapic_generator_csharp_sha256 = "6340309dc6b86bfd0dc2c9fca41cf991c7163eda2f48a7062fe4da5bd62c99d6"
+_gapic_generator_csharp_sha256 = "7f4fca6f9ec3902ae0bd0e6b96593e6370fb035ef0e56dd505f5b411b7138a7a"
 
 http_archive(
     name = "gapic_generator_csharp",
@@ -403,9 +403,9 @@ gapic_generator_csharp_repositories()
 ##############################################################################
 # Ruby
 ##############################################################################
-_gapic_generator_ruby_version = "e10d40afa96a28036da03bb9b0af17d702715886"
+_gapic_generator_ruby_version = "2b66e7aca8d5d7d4cb7bf436776d7713d264cab8"
 
-_gapic_generator_ruby_sha256 = "a560f2f0d12411b2b4f76ba087f6fcf4d517ef1e9abec1b5a517dfe348e67f3b"
+_gapic_generator_ruby_sha256 = "b00e2fa2c6f6734a32cffe77ffe5a74d02bbfaa4ad70dd92fde43c47c090b663"
 
 http_archive(
     name = "gapic_generator_ruby",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -356,7 +356,7 @@ php(
 php_gapic_repositories()
 
 # PHP micro-generator (beta)
-_gapic_generator_php_version = "0.1.7"
+_gapic_generator_php_version = "1.0.2"
 
 http_archive(
     name = "gapic_generator_php",

--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -49,6 +49,12 @@ proto_from_disco(
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load("@com_google_googleapis_imports//:imports.bzl", "proto_library_with_info")
 
+# TODO: Remove legacy rule imports after the monolith has been removed from this repo.
+load(
+    "@com_google_api_codegen//rules_gapic:gapic.bzl",
+    proto_library_with_info_legacy = "proto_library_with_info",
+)
+
 proto_library(
     name = "compute_proto",
     srcs = [
@@ -65,6 +71,14 @@ proto_library(
 
 proto_library_with_info(
     name = "compute_proto_with_info",
+    deps = [
+        ":compute_proto",
+        "@com_google_googleapis//google/cloud:common_resources_proto",
+    ],
+)
+
+proto_library_with_info_legacy(
+    name = "compute_proto_with_info_legacy",
     deps = [
         ":compute_proto",
         "@com_google_googleapis//google/cloud:common_resources_proto",
@@ -94,19 +108,35 @@ proto_library_with_info(
     ],
 )
 
+proto_library_with_info_legacy(
+    name = "compute_small_proto_with_info_legacy",
+    deps = [
+        ":compute_small_proto",
+        "@com_google_googleapis//google/cloud:common_resources_proto",
+    ],
+)
+
 ##############################################################################
 # Java
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
-    "java_gapic_assembly_gradle_pkg_legacy",
-    "java_gapic_library_legacy",
-    "java_gapic_test_legacy",
     "java_gapic_assembly_gradle_pkg",
     "java_gapic_library",
     "java_gapic_test",
-    "java_proto_library",
     "java_grpc_library",
+    "java_proto_library",
+)
+
+# TODO: Remove legacy rule imports after the monolith has been removed from this repo.
+load(
+    "@com_google_api_codegen//rules_gapic/java:java_gapic.bzl",
+    java_gapic_library_legacy = "java_gapic_library",
+    java_gapic_test_legacy = "java_gapic_test",
+)
+load(
+    "@com_google_api_codegen//rules_gapic/java:java_gapic_pkg.bzl",
+    java_gapic_assembly_gradle_pkg_legacy = "java_gapic_assembly_gradle_pkg",
 )
 
 java_proto_library(
@@ -116,12 +146,12 @@ java_proto_library(
 
 java_gapic_library_legacy(
     name = "compute_java_gapic",
-    src = ":compute_proto_with_info",
+    src = ":compute_proto_with_info_legacy",
     gapic_yaml = "compute_gapic.yaml",
     package = "google.cloud.compute.v1",
     service_yaml = "compute_v1.yaml",
-    transport = "rest",
     test_deps = [],
+    transport = "rest",
     deps = [
         ":compute_java_proto",
     ],
@@ -224,9 +254,9 @@ java_proto_library(
 # Used for integration tests
 java_gapic_library(
     name = "compute_small_java_gapic",
-    srcs = [":compute_small_proto_with_info"],
-    transport = "rest",
+    srcs = [":compute_small_proto_with_info_legacy"],
     test_deps = [],
+    transport = "rest",
     deps = [
         ":compute_small_java_proto",
     ],
@@ -294,9 +324,9 @@ py_gapic_assembly_pkg(
 ##############################################################################
 load(
     "@com_google_googleapis_imports//:imports.bzl",
-    php_gapic_assembly_pkg = "php_gapic_assembly_pkg2",
-    php_gapic_library = "php_gapic_library2",
-    php_proto_library = "php_proto_library2",
+    "php_gapic_assembly_pkg",
+    "php_gapic_library",
+    "php_proto_library",
 )
 
 php_proto_library(
@@ -371,37 +401,37 @@ nodejs_gapic_assembly_pkg(
 load(
     "@com_google_googleapis_imports//:imports.bzl",
     "ruby_cloud_gapic_library",
+    "ruby_gapic_assembly_pkg",
     "ruby_proto_library",
-    "ruby_gapic_assembly_pkg"
 )
 
 ruby_proto_library(
-  name = "compute_ruby_proto",
-  deps = [":compute_proto"],
+    name = "compute_ruby_proto",
+    deps = [":compute_proto"],
 )
 
 ruby_cloud_gapic_library(
-  name = "compute_ruby_gapic",
-  srcs = [":compute_proto_with_info"],
-  ruby_cloud_title="Google Cloud Compute V1 (ALPHA)",
-  ruby_cloud_description="google-cloud-compute-v1 is the official client library for the Google Cloud Compute V1 API. This library is considered to be in alpha. This means it is still a work-in-progress and under active development. Any release is subject to backwards-incompatible changes at any time.",
-  extra_protoc_parameters = [
-    "ruby-cloud-gem-name=google-cloud-compute-v1",
-    "ruby-cloud-env-prefix=COMPUTE",
-    "ruby-cloud-product-url=https://cloud.google.com/compute/",
-    "ruby-cloud-api-id=compute.googleapis.com",
-    "ruby-cloud-api-shortname=compute",
-    "ruby-cloud-generate-transports=rest",
-  ],
-  deps = [
-    ":compute_ruby_proto",
-  ],
+    name = "compute_ruby_gapic",
+    srcs = [":compute_proto_with_info"],
+    extra_protoc_parameters = [
+        "ruby-cloud-gem-name=google-cloud-compute-v1",
+        "ruby-cloud-env-prefix=COMPUTE",
+        "ruby-cloud-product-url=https://cloud.google.com/compute/",
+        "ruby-cloud-api-id=compute.googleapis.com",
+        "ruby-cloud-api-shortname=compute",
+        "ruby-cloud-generate-transports=rest",
+    ],
+    ruby_cloud_description = "google-cloud-compute-v1 is the official client library for the Google Cloud Compute V1 API. This library is considered to be in alpha. This means it is still a work-in-progress and under active development. Any release is subject to backwards-incompatible changes at any time.",
+    ruby_cloud_title = "Google Cloud Compute V1 (ALPHA)",
+    deps = [
+        ":compute_ruby_proto",
+    ],
 )
 
 ruby_gapic_assembly_pkg(
-  name = "google-cloud-compute-v1-ruby",
-  deps = [
-    ":compute_ruby_gapic",
-    ":compute_ruby_proto",
-  ],
+    name = "google-cloud-compute-v1-ruby",
+    deps = [
+        ":compute_ruby_gapic",
+        ":compute_ruby_proto",
+    ],
 )


### PR DESCRIPTION
As requested by @bshaffer for the [JWT auth changes](https://github.com/googleapis/gapic-generator-php/pull/309) in the PHP microgenerator.