### PR TITLE
chore: update gapic-generator-python to 0.50.5

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -220,7 +220,7 @@ load("@rules_python//python:pip.bzl", "pip_repositories")
 
 pip_repositories()
 
-_gapic_generator_python_version = "0.50.3"
+_gapic_generator_python_version = "0.50.5"
 
 http_archive(
     name = "gapic_generator_python",


### PR DESCRIPTION
https://github.com/googleapis/gapic-generator-python/blob/master/CHANGELOG.md#0505-2021-07-22

Needed to fix failing generated unit tests in https://github.com/googleapis/python-compute/pull/91