### PR TITLE
feat: update node.js build rule

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -258,9 +258,9 @@ com_googleapis_gapic_generator_go_repositories()
 # TypeScript
 ##############################################################################
 
-_gapic_generator_typescript_version = "1.5.0"
+_gapic_generator_typescript_version = "2.2.0"
 
-_gapic_generator_typescript_sha256 = "17e9387f3d6da8e5382b4e138ccc401137d2938b394040984ef2ca11ff9f8aea"
+_gapic_generator_typescript_sha256 = "e055437b1eb2ee6074363738a3cbd9a1396eaa9a74f5054240adec9cb57f9331"
 
 ### TypeScript generator
 http_archive(

--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -351,6 +351,7 @@ nodejs_gapic_library(
     package_name = "@google-cloud/compute",
     src = ":compute_proto_with_info",
     extra_protoc_parameters = ["metadata"],
+    diregapic = True,
     deps = [],
 )
 
@@ -368,6 +369,7 @@ nodejs_gapic_library(
     package_name = "@google-cloud/compute-small",
     src = ":compute_small_proto_with_info",
     extra_protoc_parameters = ["metadata"],
+    diregapic = True,
     deps = [],
 )
 

--- a/google/cloud/compute/v1/compute.proto
+++ b/google/cloud/compute/v1/compute.proto
@@ -3781,7 +3781,7 @@ message ForwardingRule {
   // - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
   // - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
   // - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-  enum IPProtocol {
+  enum IPProtocol_ {
     // A value indicating that the enum field is not set.
     UNDEFINED_I_P_PROTOCOL = 0;
 
@@ -3886,7 +3886,7 @@ message ForwardingRule {
   // - Internal HTTP(S) Load Balancing: The load balancing scheme is INTERNAL_MANAGED, and only TCP is valid.
   // - HTTP(S), SSL Proxy, and TCP Proxy Load Balancing: The load balancing scheme is EXTERNAL and only TCP is valid.
   // - Network Load Balancing: The load balancing scheme is EXTERNAL, and one of TCP or UDP is valid.
-  optional IPProtocol I_p_protocol = 488094525;
+  optional IPProtocol_ I_p_protocol = 488094525;
 
   // This field is used along with the backend_service field for internal load balancing or with the target field for internal TargetInstance. This field cannot be used with port or portRange fields.
   //


### PR DESCRIPTION
Typescript parsing the protobuf will alter the enum name to camelCase, where it throw the duplicate name error;

