### PR TITLE
chore(ruby): Include google-cloud-common in the Ruby dependencies

### DIFF
--- a/google/cloud/compute/v1/BUILD.bazel
+++ b/google/cloud/compute/v1/BUILD.bazel
@@ -410,6 +410,7 @@ ruby_cloud_gapic_library(
         "ruby-cloud-env-prefix=COMPUTE",
         "ruby-cloud-product-url=https://cloud.google.com/compute/",
         "ruby-cloud-wrapper-gem-override=",
+        "ruby-cloud-extra-dependencies=google-cloud-common=~> 1.0",
     ],
     grpc_service_config = ":compute_grpc_service_config.json",
     ruby_cloud_description = "google-cloud-compute-v1 is the official client library for the Google Cloud Compute V1 API. This library is considered to be in beta. This means while stable it is still a work-in-progress and under active development, and might get backwards-incompatible changes at any time.",


### PR DESCRIPTION
The google.cloud.common.OperationMetadata proto has been moved from googleapis-common-protos-types to google-cloud-common, so we need to include the latter explicitly in the gem dependencies.